### PR TITLE
Add readonly cluster role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0] - [Unreleased]
+
+### Added
+
+- Read-only role for customer access into Control Plane.
 
 [Unreleased]: https://github.com/giantswarm/rbac-operator/tree/master

--- a/helm/rbac-operator/templates/rbac-view-all.yaml
+++ b/helm/rbac-operator/templates/rbac-view-all.yaml
@@ -1,0 +1,162 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: view-all
+  labels:
+    app: rbac-operator
+    giantswarm.io/service-type: "managed"
+rules:
+- apiGroups:
+  - ""
+  - apiregistration.k8s.io
+  - extensions
+  - apps
+  - events.k8s.io
+  - authorization.k8s.io
+  - autoscaling
+  - batch
+  - certificates.k8s.io
+  - networking.k8s.io
+  - policy
+  - rbac.authorization.k8s.io
+  - settings.k8s.io
+  - storage.k8s.io
+  - admissionregistration.k8s.io
+  - apiextensions.k8s.io
+  - scheduling.k8s.io
+  - coordination.k8s.io
+  - auditregistration.k8s.io
+  - node.k8s.io
+  - discovery.k8s.io
+  - dex.coreos.com
+  - monitoring.coreos.com
+  - application.giantswarm.io
+  - certmanager.k8s.io
+  - cluster.k8s.io
+  - config.gatekeeper.sh
+  - constraints.gatekeeper.sh
+  - core.giantswarm.io
+  - diagnostic.giantswarm.io
+  - example.giantswarm.io
+  - giantswarm.io
+  - provider.giantswarm.io
+  - release.giantswarm.io
+  - templates.gatekeeper.sh
+  - cluster.x-k8s.io
+  - infrastructure.giantswarm.io
+  - metrics.k8s.io
+  resources:
+  - serviceaccounts
+  - endpoints
+  - resourcequotas
+  - podtemplates
+  - bindings
+  - pods
+  - limitranges
+  - persistentvolumeclaims
+  - replicationcontrollers
+  - namespaces
+  - nodes
+  - persistentvolumes
+  - services
+  - componentstatuses
+  - events
+  - apiservices
+  - ingresses
+  - statefulsets
+  - deployments
+  - replicasets
+  - controllerrevisions
+  - daemonsets
+  - tokenreviews
+  - subjectaccessreviews
+  - localsubjectaccessreviews
+  - selfsubjectrulesreviews
+  - selfsubjectaccessreviews
+  - horizontalpodautoscalers
+  - jobs
+  - cronjobs
+  - certificatesigningrequests
+  - networkpolicies
+  - poddisruptionbudgets
+  - podsecuritypolicies
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  - podpresets
+  - storageclasses
+  - volumeattachments
+  - csidrivers
+  - csinodes
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  - customresourcedefinitions
+  - priorityclasses
+  - leases
+  - auditsinks
+  - runtimeclasses
+  - endpointslices
+  - connectors
+  - oauth2clients
+  - offlinesessionses
+  - passwords
+  - authrequests
+  - signingkeies
+  - authcodes
+  - refreshtokens
+  - prometheuses
+  - alertmanagers
+  - podmonitors
+  - prometheusrules
+  - servicemonitors
+  - charts
+  - appcatalogs
+  - apps
+  - certificates
+  - issuers
+  - clusterissuers
+  - clusters
+  - machinedeployments
+  - configs
+  - uniquelabel
+  - awsclusterconfigs
+  - drainerconfigs
+  - azureclusterconfigs
+  - storageconfigs
+  - certconfigs
+  - ignitions
+  - chartconfigs
+  - kvmclusterconfigs
+  - tcpdumps
+  - servicequotas
+  - dnsnetworkpolicies
+  - canaries
+  - awstaglists
+  - awsconfigs
+  - releasecycles
+  - releases
+  - constrainttemplates
+  - awsclusters
+  - awsmachinedeployments
+  - g8scontrolplanes
+  - awscontrolplanes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: view-all
+  labels:
+    app: rbac-operator
+    giantswarm.io/service-type: "managed"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view-all
+subjects:
+- kind: Group
+  name: {{ .Values.Installation.V1.Kubernetes.Auth.ReadAccessGroup }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9248

Adding view-all role with access to read/list/watch all the resources except configmaps/secrets

Role is bounded to the group, configured in installations repo e.g. here https://github.com/giantswarm/installations/pull/1095