### PR TITLE
Add rbac manager creds for tenant admin in default namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - [Unreleased]
+## [0.3.0]- 2020-04-06
+
+### Added
+
+- Tenant admin role *tenant-admin-manage-rbac* to manage `serviceaccounts`, `roles` and `rolebindings` in default namespace.
+
+
+## [0.2.0]- 2020-03-13
+
+### Changed
+
+- Make rbac-operator optional for installation without OIDC.
+
+
+## [0.1.0]- 2020-03-13
 
 ### Added
 
 - Read-only role for customer access into Control Plane.
 
-[Unreleased]: https://github.com/giantswarm/rbac-operator/tree/master
+[Unreleased]: https://github.com/giantswarm/rbac-operator/compare/v0.3.0...HEAD
+
+[0.3.0]: https://github.com/giantswarm/rbac-operator/releases/tag/v0.3.0
+
+[0.2.0]: https://github.com/giantswarm/rbac-operator/releases/tag/v0.2.0
+
+[0.1.0]: https://github.com/giantswarm/rbac-operator/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Tenant admin role *tenant-admin-manage-rbac* to manage `serviceaccounts`, `roles` and `rolebindings` in default namespace.
+- Tenant admin role *tenant-admin-manage-rbac* to manage `serviceaccounts`, `roles`, `clusterroles`, `rolebindings` and `clusterrolebindings`.
 
 
 ## [0.2.0]- 2020-03-13

--- a/helm/rbac-operator/templates/rbac-tenant-admin.yaml
+++ b/helm/rbac-operator/templates/rbac-tenant-admin.yaml
@@ -87,7 +87,7 @@ roleRef:
   name: tenant-admin-manage-rbac
 subjects:
 - kind: Group
-  name: {{ .Values.Installation.V1.Kubernetes.Auth.TenantAdminTargetGroup }}`
+  name: {{ .Values.Installation.V1.Kubernetes.Auth.TenantAdminTargetGroup }}
 ---
 # view-all access
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/rbac-operator/templates/rbac-tenant-admin.yaml
+++ b/helm/rbac-operator/templates/rbac-tenant-admin.yaml
@@ -36,14 +36,12 @@ rules:
   - update
   - patch
   - delete
-# access to create RBAC in default namespace
-# should be changed with access to create SAs in `installation`/`<organization-name>` namespaces
-# after cluster CRs moved into organization namespaces.
+---
+# access to manage RBAC
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: tenant-admin-manage-rbac
-  namespace: default
   labels:
     app: rbac-operator
     giantswarm.io/service-type: "managed"
@@ -53,30 +51,45 @@ rules:
   resources:
   - serviceaccounts
   verbs:
-  - *
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - clusterroles
+  - clusterrolebindings
   - roles
   - rolebindings
   verbs:
-  - *
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: tenant-admin
+  name: tenant-admin-manage-rbac
   labels:
     app: rbac-operator
     giantswarm.io/service-type: "managed"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tenant-admin
+  name: tenant-admin-manage-rbac
 subjects:
 - kind: Group
-  name: {{ .Values.Installation.V1.Kubernetes.Auth.TenantAdminTargetGroup }}
+  name: {{ .Values.Installation.V1.Kubernetes.Auth.TenantAdminTargetGroup }}`
 ---
+# view-all access
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/helm/rbac-operator/templates/rbac-tenant-admin.yaml
+++ b/helm/rbac-operator/templates/rbac-tenant-admin.yaml
@@ -36,6 +36,31 @@ rules:
   - update
   - patch
   - delete
+# access to create RBAC in default namespace
+# should be changed with access to create SAs in `installation`/`<organization-name>` namespaces
+# after cluster CRs moved into organization namespaces.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tenant-admin-manage-rbac
+  namespace: default
+  labels:
+    app: rbac-operator
+    giantswarm.io/service-type: "managed"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - *
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - *
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -63,6 +88,22 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: view-all
+subjects:
+- kind: Group
+  name: {{ .Values.Installation.V1.Kubernetes.Auth.TenantAdminTargetGroup }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tenant-admin-manage-rbac
+  labels:
+    app: rbac-operator
+    giantswarm.io/service-type: "managed"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tenant-admin-manage-rbac
+  namespace: default
 subjects:
 - kind: Group
   name: {{ .Values.Installation.V1.Kubernetes.Auth.TenantAdminTargetGroup }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9883

Customers should be able to create serviceaccounts for their automation tooling, which can manage clusters CRs in installation