### PR TITLE
Add namespacelabeler controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Push tags to *aliyun* repository.
 - Move `rbac` controller code into `rbac` package.
+- Add `namespacelabeler` controller, which labels legacy namespaces.
 
 ## [0.3.3] - 2020-05-13
 

--- a/helm/rbac-operator/templates/deployment.yaml
+++ b/helm/rbac-operator/templates/deployment.yaml
@@ -12,7 +12,6 @@ spec:
   selector:
     matchLabels:
       app: {{ .Values.project.name }}
-      version: {{ .Values.project.version }}
   strategy:
     type: Recreate
   template:
@@ -30,7 +29,6 @@ spec:
               labelSelector:
                 matchLabels:
                   app: {{ .Values.project.name }}
-                  version: {{ .Values.project.version }}
               topologyKey: kubernetes.io/hostname
             weight: 100
       volumes:

--- a/helm/rbac-operator/templates/rbac.yaml
+++ b/helm/rbac-operator/templates/rbac.yaml
@@ -12,6 +12,7 @@ rules:
       - get
       - list
       - patch
+      - update
       - watch
   - apiGroups:
       - "rbac.authorization.k8s.io"

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -3,4 +3,7 @@ package label
 const (
 	Cluster      = "giantswarm.io/cluster"
 	Organization = "giantswarm.io/organization"
+	// Labels, used in legacy cluster namespaces
+	LegacyCluster  = "cluster"
+	LegacyCustomer = "customer"
 )

--- a/service/controller/namespacelabeler/key/error.go
+++ b/service/controller/namespacelabeler/key/error.go
@@ -1,0 +1,11 @@
+package key
+
+import "github.com/giantswarm/microerror"
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/namespacelabeler/key/key.go
+++ b/service/controller/namespacelabeler/key/key.go
@@ -1,0 +1,21 @@
+package key
+
+import (
+	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func ToNamespace(v interface{}) (corev1.Namespace, error) {
+	if v == nil {
+		return corev1.Namespace{}, microerror.Maskf(wrongTypeError, "expected non-nil, got %#v'", v)
+	}
+
+	p, ok := v.(*corev1.Namespace)
+	if !ok {
+		return corev1.Namespace{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", p, v)
+	}
+
+	c := p.DeepCopy()
+
+	return *c, nil
+}

--- a/service/controller/namespacelabeler/key/key.go
+++ b/service/controller/namespacelabeler/key/key.go
@@ -5,17 +5,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func ToNamespace(v interface{}) (corev1.Namespace, error) {
+func ToNamespace(v interface{}) (*corev1.Namespace, error) {
 	if v == nil {
-		return corev1.Namespace{}, microerror.Maskf(wrongTypeError, "expected non-nil, got %#v'", v)
+		return &corev1.Namespace{}, microerror.Maskf(wrongTypeError, "expected non-nil, got %#v'", v)
 	}
 
 	p, ok := v.(*corev1.Namespace)
 	if !ok {
-		return corev1.Namespace{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", p, v)
+		return &corev1.Namespace{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", p, v)
 	}
 
 	c := p.DeepCopy()
 
-	return *c, nil
+	return c, nil
 }

--- a/service/controller/namespacelabeler/namespace_labeler.go
+++ b/service/controller/namespacelabeler/namespace_labeler.go
@@ -1,0 +1,67 @@
+package namespacelabeler
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/giantswarm/rbac-operator/pkg/label"
+	"github.com/giantswarm/rbac-operator/pkg/project"
+)
+
+type NamespaceLabelerConfig struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+}
+
+type NamespaceLabeler struct {
+	*controller.Controller
+}
+
+func NewNamespaceLabeler(config NamespaceLabelerConfig) (*NamespaceLabeler, error) {
+	var err error
+
+	resourceSet, err := NewNamespaceLabelerResourceSet(config)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var namespaceLabelerController *controller.Controller
+	{
+
+		namespaceSelectorQuery := fmt.Sprintf("%s,%s", label.LegacyCluster, label.LegacyCustomer)
+		namespaceSelector, err := labels.Parse(namespaceSelectorQuery)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		c := controller.Config{
+			K8sClient:    config.K8sClient,
+			Logger:       config.Logger,
+			ResourceSets: []*controller.ResourceSet{resourceSet},
+			NewRuntimeObjectFunc: func() runtime.Object {
+				return new(corev1.Namespace)
+			},
+			Selector: namespaceSelector,
+
+			Name: project.Name() + "-namespace-labeler-controller",
+		}
+
+		namespaceLabelerController, err = controller.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	c := &NamespaceLabeler{
+		Controller: namespaceLabelerController,
+	}
+
+	return c, nil
+}

--- a/service/controller/namespacelabeler/namespace_labeler.go
+++ b/service/controller/namespacelabeler/namespace_labeler.go
@@ -35,7 +35,7 @@ func NewNamespaceLabeler(config NamespaceLabelerConfig) (*NamespaceLabeler, erro
 	var namespaceLabelerController *controller.Controller
 	{
 
-		namespaceSelectorQuery := fmt.Sprintf("%s=,%s=,%s!=,%s!=", label.LegacyCluster, label.LegacyCustomer, label.Cluster, label.Organization)
+		namespaceSelectorQuery := fmt.Sprintf("%s,%s", label.LegacyCluster, label.LegacyCustomer)
 		namespaceSelector, err := labels.Parse(namespaceSelectorQuery)
 		if err != nil {
 			return nil, microerror.Mask(err)

--- a/service/controller/namespacelabeler/namespace_labeler.go
+++ b/service/controller/namespacelabeler/namespace_labeler.go
@@ -35,7 +35,7 @@ func NewNamespaceLabeler(config NamespaceLabelerConfig) (*NamespaceLabeler, erro
 	var namespaceLabelerController *controller.Controller
 	{
 
-		namespaceSelectorQuery := fmt.Sprintf("%s,%s", label.LegacyCluster, label.LegacyCustomer)
+		namespaceSelectorQuery := fmt.Sprintf("%s=,%s=,%s!=,%s!=", label.LegacyCluster, label.LegacyCustomer, label.Cluster, label.Organization)
 		namespaceSelector, err := labels.Parse(namespaceSelectorQuery)
 		if err != nil {
 			return nil, microerror.Mask(err)

--- a/service/controller/namespacelabeler/namespace_labeler.go
+++ b/service/controller/namespacelabeler/namespace_labeler.go
@@ -50,7 +50,10 @@ func NewNamespaceLabeler(config NamespaceLabelerConfig) (*NamespaceLabeler, erro
 			},
 			Selector: namespaceSelector,
 
-			Name: project.Name() + "-namespace-labeler-controller",
+			// TODO: use namespace-labeler-controller name after operatokit allows disabling finalizer
+			// For now we need to have the same name for both controllers so that finalizer logic gets executed
+			// when current controller stops watching modified namespaces.
+			Name: project.Name() + "-rbac-controller",
 		}
 
 		namespaceLabelerController, err = controller.New(c)

--- a/service/controller/namespacelabeler/namespace_labeler_resource_set.go
+++ b/service/controller/namespacelabeler/namespace_labeler_resource_set.go
@@ -1,0 +1,78 @@
+package namespacelabeler
+
+import (
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/resource"
+	"github.com/giantswarm/operatorkit/resource/wrapper/metricsresource"
+	"github.com/giantswarm/operatorkit/resource/wrapper/retryresource"
+	"github.com/giantswarm/rbac-operator/service/controller/namespacelabeler/resource/namespacelabel"
+)
+
+type NamespaceLabelerResourceSetConfig struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+}
+
+func NewNamespaceLabelerResourceSet(config NamespaceLabelerConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	var namespaceLabelResource resource.Interface
+	{
+		c := namespacelabel.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		namespaceLabelResource, err = namespacelabel.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []resource.Interface{
+		namespaceLabelResource,
+	}
+
+	{
+		c := retryresource.WrapConfig{
+			Logger: config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{}
+
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	handlesFunc := func(obj interface{}) bool {
+		return true
+	}
+
+	var resourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		resourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resourceSet, nil
+}

--- a/service/controller/namespacelabeler/resource/namespacelabel/create.go
+++ b/service/controller/namespacelabeler/resource/namespacelabel/create.go
@@ -1,0 +1,41 @@
+package namespacelabel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/rbac-operator/pkg/label"
+	"github.com/giantswarm/rbac-operator/service/controller/namespacelabeler/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	namespace, err := key.ToNamespace(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if needsUpdate(namespace) {
+		namespace.ObjectMeta.Labels[label.Cluster] = ""
+		namespace.ObjectMeta.Labels[label.Organization] = ""
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("applying new labels to namespace"))
+		_, err = r.k8sClient.CoreV1().Namespaces().Update(&namespace)
+		if err != nil {
+			return microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("new labels has been applied"))
+		}
+	}
+
+	return nil
+}
+
+func needsUpdate(ns corev1.Namespace) bool {
+	_, legacyClusterOK := ns.ObjectMeta.Labels[label.LegacyCluster]
+	_, legactCustomerOK := ns.ObjectMeta.Labels[label.LegacyCustomer]
+
+	return !(legacyClusterOK && legactCustomerOK)
+}

--- a/service/controller/namespacelabeler/resource/namespacelabel/create.go
+++ b/service/controller/namespacelabeler/resource/namespacelabel/create.go
@@ -17,8 +17,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	if needsUpdate(namespace) {
-		namespace.ObjectMeta.Labels[label.Cluster] = ""
-		namespace.ObjectMeta.Labels[label.Organization] = ""
+		namespace.ObjectMeta.Labels[label.Cluster] = ns.ObjectMeta.Labels[label.LegacyCluster]
+		namespace.ObjectMeta.Labels[label.Organization] = ns.ObjectMeta.Labels[label.LegacyCustomer]
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "applying new labels to namespace")
 		_, err = r.k8sClient.CoreV1().Namespaces().Update(namespace)

--- a/service/controller/namespacelabeler/resource/namespacelabel/create.go
+++ b/service/controller/namespacelabeler/resource/namespacelabel/create.go
@@ -2,7 +2,6 @@ package namespacelabel
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
@@ -21,21 +20,21 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		namespace.ObjectMeta.Labels[label.Cluster] = ""
 		namespace.ObjectMeta.Labels[label.Organization] = ""
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("applying new labels to namespace"))
-		_, err = r.k8sClient.CoreV1().Namespaces().Update(&namespace)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "applying new labels to namespace")
+		_, err = r.k8sClient.CoreV1().Namespaces().Update(namespace)
 		if err != nil {
 			return microerror.Mask(err)
 		} else {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("new labels has been applied"))
+			r.logger.LogCtx(ctx, "level", "debug", "message", "new labels has been applied")
 		}
 	}
 
 	return nil
 }
 
-func needsUpdate(ns corev1.Namespace) bool {
-	_, legacyClusterOK := ns.ObjectMeta.Labels[label.LegacyCluster]
-	_, legactCustomerOK := ns.ObjectMeta.Labels[label.LegacyCustomer]
+func needsUpdate(ns *corev1.Namespace) bool {
+	_, clusterOK := ns.ObjectMeta.Labels[label.Cluster]
+	_, organizationOK := ns.ObjectMeta.Labels[label.Organization]
 
-	return !(legacyClusterOK && legactCustomerOK)
+	return !(clusterOK && organizationOK)
 }

--- a/service/controller/namespacelabeler/resource/namespacelabel/create.go
+++ b/service/controller/namespacelabeler/resource/namespacelabel/create.go
@@ -17,8 +17,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	if needsUpdate(namespace) {
-		namespace.ObjectMeta.Labels[label.Cluster] = ns.ObjectMeta.Labels[label.LegacyCluster]
-		namespace.ObjectMeta.Labels[label.Organization] = ns.ObjectMeta.Labels[label.LegacyCustomer]
+		namespace.ObjectMeta.Labels[label.Cluster] = namespace.ObjectMeta.Labels[label.LegacyCluster]
+		namespace.ObjectMeta.Labels[label.Organization] = namespace.ObjectMeta.Labels[label.LegacyCustomer]
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "applying new labels to namespace")
 		_, err = r.k8sClient.CoreV1().Namespaces().Update(namespace)

--- a/service/controller/namespacelabeler/resource/namespacelabel/create.go
+++ b/service/controller/namespacelabeler/resource/namespacelabel/create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-	corev1 "k8s.io/api/core/v1"
 
 	"github.com/giantswarm/rbac-operator/pkg/label"
 	"github.com/giantswarm/rbac-operator/service/controller/namespacelabeler/key"
@@ -16,25 +15,16 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	if needsUpdate(namespace) {
-		namespace.ObjectMeta.Labels[label.Cluster] = namespace.ObjectMeta.Labels[label.LegacyCluster]
-		namespace.ObjectMeta.Labels[label.Organization] = namespace.ObjectMeta.Labels[label.LegacyCustomer]
+	namespace.ObjectMeta.Labels[label.Cluster] = namespace.ObjectMeta.Labels[label.LegacyCluster]
+	namespace.ObjectMeta.Labels[label.Organization] = namespace.ObjectMeta.Labels[label.LegacyCustomer]
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "applying new labels to namespace")
-		_, err = r.k8sClient.CoreV1().Namespaces().Update(namespace)
-		if err != nil {
-			return microerror.Mask(err)
-		} else {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "new labels has been applied")
-		}
+	r.logger.LogCtx(ctx, "level", "debug", "message", "applying new labels to namespace")
+	_, err = r.k8sClient.CoreV1().Namespaces().Update(namespace)
+	if err != nil {
+		return microerror.Mask(err)
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "new labels has been applied")
 	}
 
 	return nil
-}
-
-func needsUpdate(ns *corev1.Namespace) bool {
-	_, clusterOK := ns.ObjectMeta.Labels[label.Cluster]
-	_, organizationOK := ns.ObjectMeta.Labels[label.Organization]
-
-	return !(clusterOK && organizationOK)
 }

--- a/service/controller/namespacelabeler/resource/namespacelabel/delete.go
+++ b/service/controller/namespacelabeler/resource/namespacelabel/delete.go
@@ -1,0 +1,9 @@
+package namespacelabel
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/namespacelabeler/resource/namespacelabel/error.go
+++ b/service/controller/namespacelabeler/resource/namespacelabel/error.go
@@ -1,0 +1,14 @@
+package namespacelabel
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/namespacelabeler/resource/namespacelabel/resource.go
+++ b/service/controller/namespacelabeler/resource/namespacelabel/resource.go
@@ -1,0 +1,43 @@
+package namespacelabel
+
+import (
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "namespacelabel"
+)
+
+type Config struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient: config.K8sClient.K8sClient(),
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/service.go
+++ b/service/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/giantswarm/rbac-operator/flag"
 	"github.com/giantswarm/rbac-operator/pkg/project"
 	"github.com/giantswarm/rbac-operator/service/collector"
+	"github.com/giantswarm/rbac-operator/service/controller/namespacelabeler"
 	"github.com/giantswarm/rbac-operator/service/controller/rbac"
 
 	"github.com/giantswarm/rbac-operator/service/controller/rbac/resource/namespaceauth"
@@ -34,9 +35,10 @@ type Config struct {
 type Service struct {
 	Version *version.Service
 
-	bootOnce          sync.Once
-	rbacController    *rbac.RBAC
-	operatorCollector *collector.Set
+	bootOnce                   sync.Once
+	namespaceLabelerController *namespacelabeler.NamespaceLabeler
+	rbacController             *rbac.RBAC
+	operatorCollector          *collector.Set
 }
 
 // New creates a new configured service object.
@@ -86,11 +88,7 @@ func New(config Config) (*Service, error) {
 	var k8sClient k8sclient.Interface
 	{
 		c := k8sclient.ClientsConfig{
-			Logger: config.Logger,
-			// TODO: If you are watching a new CRD, include here the AddToScheme function from apiextensions.
-			// SchemeBuilder: k8sclient.SchemeBuilder{
-			//     corev1alpha1.AddToScheme,
-			// },
+			Logger:     config.Logger,
 			RestConfig: restConfig,
 		}
 
@@ -114,6 +112,20 @@ func New(config Config) (*Service, error) {
 		}
 
 		rbacController, err = rbac.NewRBAC(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var namespaceLabelerController *namespacelabeler.NamespaceLabeler
+	{
+
+		c := namespacelabeler.NamespaceLabelerConfig{
+			K8sClient: k8sClient,
+			Logger:    config.Logger,
+		}
+
+		namespaceLabelerController, err = namespacelabeler.NewNamespaceLabeler(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -152,9 +164,10 @@ func New(config Config) (*Service, error) {
 	s := &Service{
 		Version: versionService,
 
-		bootOnce:          sync.Once{},
-		rbacController:    rbacController,
-		operatorCollector: operatorCollector,
+		bootOnce:                   sync.Once{},
+		namespaceLabelerController: namespaceLabelerController,
+		rbacController:             rbacController,
+		operatorCollector:          operatorCollector,
 	}
 
 	return s, nil

--- a/service/service.go
+++ b/service/service.go
@@ -176,6 +176,7 @@ func New(config Config) (*Service, error) {
 func (s *Service) Boot(ctx context.Context) {
 	s.bootOnce.Do(func() {
 		go s.operatorCollector.Boot(ctx)
+		go s.namespaceLabelerController.Boot(ctx)
 
 		go s.rbacController.Boot(ctx)
 	})


### PR DESCRIPTION
For legacy namespaces, which have labels `cluster`/`customer` - add labels `giantswarm.io/cluster` and `giantswarm.io/organization` so that rbac controller can manage rbac for those namespaces

## Checklist

- [x] Update changelog in CHANGELOG.md.
