### PR TITLE
Add automation serviceaccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Push tags to *aliyun* repository.
 - Move `rbac` controller code into `rbac` package.
 - Add `namespacelabeler` controller, which labels legacy namespaces.
+- Add `automation` service account in `global` namespace, which has admin access to all the tenant namespaces.
 
 ## [0.3.3] - 2020-05-13
 

--- a/helm/rbac-operator/templates/rbac-tenant-admin.yaml
+++ b/helm/rbac-operator/templates/rbac-tenant-admin.yaml
@@ -121,7 +121,6 @@ subjects:
 - kind: Group
   name: {{ .Values.Installation.V1.Kubernetes.Auth.TenantAdminTargetGroup }}
 ---
-# `automation` serviceaccount in `global` namespace
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/rbac-operator/templates/rbac-tenant-admin.yaml
+++ b/helm/rbac-operator/templates/rbac-tenant-admin.yaml
@@ -121,6 +121,13 @@ subjects:
 - kind: Group
   name: {{ .Values.Installation.V1.Kubernetes.Auth.TenantAdminTargetGroup }}
 ---
+# `automation` serviceaccount in `global` namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: automation
+  namespace: global
+```
 # `global` namespace admin
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/rbac-operator/templates/rbac-tenant-admin.yaml
+++ b/helm/rbac-operator/templates/rbac-tenant-admin.yaml
@@ -127,7 +127,7 @@ kind: ServiceAccount
 metadata:
   name: automation
   namespace: global
-```
+---
 # `global` namespace admin
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -3,6 +3,9 @@ package label
 const (
 	Cluster      = "giantswarm.io/cluster"
 	Organization = "giantswarm.io/organization"
+
+	ManagedBy = "giantswarm.io/managed-by"
+
 	// Labels, used in legacy cluster namespaces
 	LegacyCluster  = "cluster"
 	LegacyCustomer = "customer"

--- a/service/controller/rbac/key/key.go
+++ b/service/controller/rbac/key/key.go
@@ -6,10 +6,10 @@ import (
 )
 
 const (
-	automationServiceAccountName      = "automation"
-	automationServiceAccountNamespace = "global"
-	tenantAdminRoleName               = "tenant-admin"
-	viewAllRoleName                   = "view-all"
+	AutomationServiceAccountName      = "automation"
+	AutomationServiceAccountNamespace = "global"
+	TenantAdminRoleName               = "tenant-admin"
+	ViewAllRoleName                   = "view-all"
 )
 
 func ToNamespace(v interface{}) (corev1.Namespace, error) {

--- a/service/controller/rbac/key/key.go
+++ b/service/controller/rbac/key/key.go
@@ -5,6 +5,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	automationServiceAccountName      = "automation"
+	automationServiceAccountNamespace = "global"
+	tenantAdminRoleName               = "tenant-admin"
+	viewAllRoleName                   = "view-all"
+)
+
 func ToNamespace(v interface{}) (corev1.Namespace, error) {
 	if v == nil {
 		return corev1.Namespace{}, microerror.Maskf(wrongTypeError, "expected non-nil, got %#v'", v)

--- a/service/controller/rbac/key/key.go
+++ b/service/controller/rbac/key/key.go
@@ -5,13 +5,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const (
-	AutomationServiceAccountName      = "automation"
-	AutomationServiceAccountNamespace = "global"
-	TenantAdminRoleName               = "tenant-admin"
-	ViewAllRoleName                   = "view-all"
-)
-
 func ToNamespace(v interface{}) (corev1.Namespace, error) {
 	if v == nil {
 		return corev1.Namespace{}, microerror.Maskf(wrongTypeError, "expected non-nil, got %#v'", v)

--- a/service/controller/rbac/resource/namespaceauth/create.go
+++ b/service/controller/rbac/resource/namespaceauth/create.go
@@ -99,7 +99,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		{
 			roleBindingName := fmt.Sprintf("%s-sa", role.name)
-			newServiceAccountRoleBinding := newServiceAccountRoleBinding(roleBindingName, key.AutomationServiceAccountName, key.AutomationServiceAccountNamespace)
+			newServiceAccountRoleBinding := newServiceAccountRoleBinding(roleBindingName, automationServiceAccountName, automationServiceAccountNamespace)
 
 			existingRoleBinding, err := r.k8sClient.RbacV1().RoleBindings(namespace.Name).Get(newServiceAccountRoleBinding.Name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {

--- a/service/controller/rbac/resource/namespaceauth/create.go
+++ b/service/controller/rbac/resource/namespaceauth/create.go
@@ -66,7 +66,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 
 		{
-			newGroupRoleBinding := newGroupRoleBinding(role.name, role.targetGroup)
+			roleBindingName := fmt.Sprintf("%s-group", role.name)
+			newGroupRoleBinding := newGroupRoleBinding(roleBindingName, role.targetGroup)
 
 			existingRoleBinding, err := r.k8sClient.RbacV1().RoleBindings(namespace.Name).Get(newGroupRoleBinding.Name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
@@ -97,7 +98,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 
 		{
-			newServiceAccountRoleBinding := newServiceAccountRoleBinding(role.name, key.AutomationServiceAccountName, key.AutomationServiceAccountNamespace)
+			roleBindingName := fmt.Sprintf("%s-sa", role.name)
+			newServiceAccountRoleBinding := newServiceAccountRoleBinding(roleBindingName, key.AutomationServiceAccountName, key.AutomationServiceAccountNamespace)
 
 			existingRoleBinding, err := r.k8sClient.RbacV1().RoleBindings(namespace.Name).Get(newServiceAccountRoleBinding.Name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {

--- a/service/controller/rbac/resource/namespaceauth/resource.go
+++ b/service/controller/rbac/resource/namespaceauth/resource.go
@@ -4,6 +4,8 @@ import (
 	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/rbac-operator/pkg/label"
+	"github.com/giantswarm/rbac-operator/pkg/project"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -114,6 +116,9 @@ func newRole(name string, resources []*metav1.APIResourceList, verbs []string) (
 	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+			Labels: map[string]string{
+				label.ManagedBy: project.Name(),
+			},
 		},
 		Rules: []rbacv1.PolicyRule{
 			rbacv1.PolicyRule{
@@ -135,6 +140,9 @@ func newGroupRoleBinding(name, targetGroupName string) *rbacv1.RoleBinding {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+			Labels: map[string]string{
+				label.ManagedBy: project.Name(),
+			},
 		},
 		Subjects: []rbacv1.Subject{
 			rbacv1.Subject{
@@ -160,6 +168,9 @@ func newServiceAccountRoleBinding(name, serviceAccountName, serviceAccountNamesp
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+			Labels: map[string]string{
+				label.ManagedBy: project.Name(),
+			},
 		},
 		Subjects: []rbacv1.Subject{
 			rbacv1.Subject{

--- a/service/controller/rbac/resource/namespaceauth/resource.go
+++ b/service/controller/rbac/resource/namespaceauth/resource.go
@@ -12,9 +12,7 @@ import (
 )
 
 const (
-	Name                = "namespaceauth"
-	tenantAdminRoleName = "tenant-admin"
-	viewAllRoleName     = "view-all"
+	Name = "namespaceauth"
 )
 
 type Config struct {
@@ -124,7 +122,7 @@ func newRole(name string, resources []*metav1.APIResourceList, verbs []string) (
 	return role, nil
 }
 
-func newRoleBinding(name, targetGroupName string) *rbacv1.RoleBinding {
+func newGroupRoleBinding(name, targetGroupName string) *rbacv1.RoleBinding {
 	roleBinding := &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "RoleBinding",

--- a/service/controller/rbac/resource/namespaceauth/resource.go
+++ b/service/controller/rbac/resource/namespaceauth/resource.go
@@ -146,3 +146,29 @@ func newGroupRoleBinding(name, targetGroupName string) *rbacv1.RoleBinding {
 
 	return roleBinding
 }
+
+func newServiceAccountRoleBinding(name, serviceAccountName, serviceAccountNamespace string) *rbacv1.RoleBinding {
+	roleBinding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Subjects: []rbacv1.Subject{
+			rbacv1.Subject{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccountName,
+				Namespace: serviceAccountNamespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     name,
+		},
+	}
+
+	return roleBinding
+}

--- a/service/controller/rbac/resource/namespaceauth/resource.go
+++ b/service/controller/rbac/resource/namespaceauth/resource.go
@@ -13,6 +13,11 @@ import (
 
 const (
 	Name = "namespaceauth"
+
+	automationServiceAccountName      = "automation"
+	automationServiceAccountNamespace = "global"
+	tenantAdminRoleName               = "tenant-admin"
+	viewAllRoleName                   = "view-all"
 )
 
 type Config struct {


### PR DESCRIPTION
Service account `automation` will be created in `global` namespace. It can be used for further rbac management in CI pipelines

## Checklist

- [x] Update changelog in CHANGELOG.md.
