### PR TITLE
Revert "Fix update logic"

### DIFF
--- a/service/controller/rbac/resource/namespaceauth/create.go
+++ b/service/controller/rbac/resource/namespaceauth/create.go
@@ -134,5 +134,5 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 }
 
 func needsUpdate(role role, existingRoleBinding *rbacv1.RoleBinding) bool {
-	return role.targetGroup != existingRoleBinding.Subjects[0].Name || role.name != existingRoleBinding.RoleRef.Name
+	return role.targetGroup != existingRoleBinding.Subjects[0].Name
 }


### PR DESCRIPTION
This reverts commit 3b0cc187dfdf99ed0c37b80f341a2950f18c0908.

updating of the role reference is not supported.
I'll manually cleanup affected clusters

## Checklist

- [ ] Update changelog in CHANGELOG.md.
