### PR TITLE
Update role rules when they are not up to date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Update Roles when their Rules are not up to date.
+
 ## [0.6.0] - 2020-09-24
 
 ### Changed

--- a/service/controller/rbac/resource/namespaceauth/create.go
+++ b/service/controller/rbac/resource/namespaceauth/create.go
@@ -64,12 +64,14 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		} else {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("role %#q already exists", newRole.Name))
-		}
 
-		if !reflect.DeepEqual(newRole.Rules, existingRole.Rules) {
-			_, err := r.k8sClient.RbacV1().Roles(namespace.Name).Update(ctx, newRole, metav1.UpdateOptions{})
-			if err != nil {
-				return microerror.Mask(err)
+			if !reflect.DeepEqual(newRole.Rules, existingRole.Rules) {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("rules in role %#q need to be updated", newRole.Name))
+				_, err := r.k8sClient.RbacV1().Roles(namespace.Name).Update(ctx, newRole, metav1.UpdateOptions{})
+				if err != nil {
+					return microerror.Mask(err)
+				}
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("role %#q has been updated", newRole.Name))
 			}
 		}
 


### PR DESCRIPTION
When a new CRD is added **after** a `Role` has already been created, the role doesn't have enough permissions to work with the new type. We need to update the `Role` when new CRDs are added.

## Checklist

- [X] Update changelog in CHANGELOG.md.
