### PR TITLE
Compare existing role binding with desired role binding to decide whether or not to update it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Roles when their Rules are not up to date.
 
+### Fixed
+
+- Update `RoleBindings` only when necessary.
+
 ## [0.6.0] - 2020-09-24
 
 ### Changed

--- a/service/controller/rbac/resource/namespaceauth/create.go
+++ b/service/controller/rbac/resource/namespaceauth/create.go
@@ -95,7 +95,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 			} else if err != nil {
 				return microerror.Mask(err)
-			} else if needsUpdate(role, existingRoleBinding) {
+			} else if needsUpdate(newGroupRoleBinding, existingRoleBinding) {
 				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating role binding %#q", newGroupRoleBinding.Name))
 				_, err := r.k8sClient.RbacV1().RoleBindings(namespace.Name).Update(ctx, newGroupRoleBinding, metav1.UpdateOptions{})
 				if err != nil {
@@ -127,7 +127,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 			} else if err != nil {
 				return microerror.Mask(err)
-			} else if needsUpdate(role, existingRoleBinding) {
+			} else if needsUpdate(newServiceAccountRoleBinding, existingRoleBinding) {
 				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating role binding %#q", newServiceAccountRoleBinding.Name))
 				_, err := r.k8sClient.RbacV1().RoleBindings(namespace.Name).Update(ctx, newServiceAccountRoleBinding, metav1.UpdateOptions{})
 				if err != nil {
@@ -144,8 +144,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	return nil
 }
 
-func needsUpdate(role role, existingRoleBinding *rbacv1.RoleBinding) bool {
-	return role.targetGroup != existingRoleBinding.Subjects[0].Name
+func needsUpdate(desiredRoleBinding, existingRoleBinding *rbacv1.RoleBinding) bool {
+	return desiredRoleBinding.Subjects[0].Name != existingRoleBinding.Subjects[0].Name
 }
 
 func areRolesEqual(role1, role2 *rbacv1.Role) bool {


### PR DESCRIPTION
I noticed that the `RoleBindings` are being on every reconciliation loop. The check to decide whether to update it or not always returns `true`, so it's always updated.

I believe the check may contain a mistake, and the intention was to compare the current role binding with the desired state of the role binding. I changed the code to do that.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
