### PR TITLE
Add binding controller

### DIFF
--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -1,6 +1,9 @@
 package key
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
 	AutomationServiceAccountName   = "automation"
@@ -9,6 +12,18 @@ const (
 	DefaultWriteAllPermissionsName = "write-all"
 	DefaultNamespaceName           = "default"
 )
+
+func IsOrgNamespace(ns string) bool {
+	return strings.HasPrefix(ns, "org-")
+}
+
+func OrganizationName(ns string) string {
+	return strings.TrimPrefix(ns, "org-")
+}
+
+func OrganizationReadClusterRoleName(ns string) string {
+	return fmt.Sprintf("%s-read", strings.TrimPrefix(ns, "org-"))
+}
 
 func ReadAllCustomerGroupClusterRoleBindingName() string {
 	return fmt.Sprintf("%s-customer-group", DefaultReadAllPermissionsName)

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -22,7 +22,11 @@ func OrganizationName(ns string) string {
 }
 
 func OrganizationReadClusterRoleName(ns string) string {
-	return fmt.Sprintf("%s-read", strings.TrimPrefix(ns, "org-"))
+	return fmt.Sprintf("%s-organization-read", strings.TrimPrefix(ns, "org-"))
+}
+
+func OrganizationReadRoleBindingName(roleBinding string) string {
+	return fmt.Sprintf("%s-organization-read", roleBinding)
 }
 
 func ReadAllCustomerGroupClusterRoleBindingName() string {

--- a/service/controller/orgpermissions/key/error.go
+++ b/service/controller/orgpermissions/key/error.go
@@ -1,0 +1,11 @@
+package key
+
+import "github.com/giantswarm/microerror"
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/orgpermissions/key/key.go
+++ b/service/controller/orgpermissions/key/key.go
@@ -1,0 +1,21 @@
+package key
+
+import (
+	"github.com/giantswarm/microerror"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func ToRoleBinding(v interface{}) (rbacv1.RoleBinding, error) {
+	if v == nil {
+		return rbacv1.RoleBinding{}, microerror.Maskf(wrongTypeError, "expected non-nil, got %#v'", v)
+	}
+
+	p, ok := v.(*rbacv1.RoleBinding)
+	if !ok {
+		return rbacv1.RoleBinding, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", p, v)
+	}
+
+	c := p.DeepCopy()
+
+	return *c, nil
+}

--- a/service/controller/orgpermissions/key/key.go
+++ b/service/controller/orgpermissions/key/key.go
@@ -12,7 +12,7 @@ func ToRoleBinding(v interface{}) (rbacv1.RoleBinding, error) {
 
 	p, ok := v.(*rbacv1.RoleBinding)
 	if !ok {
-		return rbacv1.RoleBinding, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", p, v)
+		return rbacv1.RoleBinding{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", p, v)
 	}
 
 	c := p.DeepCopy()

--- a/service/controller/orgpermissions/orgpermissions.go
+++ b/service/controller/orgpermissions/orgpermissions.go
@@ -1,0 +1,63 @@
+package orgpermissions
+
+import (
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/v2/pkg/controller"
+	"github.com/giantswarm/operatorkit/v2/pkg/resource"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/giantswarm/rbac-operator/pkg/project"
+)
+
+type OrgPermissionsConfig struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+}
+
+type OrgPermissions struct {
+	*controller.Controller
+}
+
+func NewOrgPermissions(config OrgPermissionsConfig) (*OrgPermissions, error) {
+	var err error
+
+	var resources []resource.Interface
+	{
+		c := orgPermissionsResourcesConfig(config)
+
+		resources, err = NewOrgPermissionsResources(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var organizationPermissionsController *controller.Controller
+	{
+		c := controller.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+			NewRuntimeObjectFunc: func() runtime.Object {
+				return new(rbacv1.RoleBinding)
+			},
+			Resources: resources,
+
+			// Name is used to compute finalizer names. This here results in something
+			// like operatorkit.giantswarm.io/rbac-operator-RBAC-controller.
+			Name: project.Name() + "-orgpermissions-controller",
+		}
+
+		organizationPermissionsController, err = controller.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	c := &OrgPermissions{
+		Controller: organizationPermissionsController,
+	}
+
+	return c, nil
+}

--- a/service/controller/orgpermissions/orgpermissions.go
+++ b/service/controller/orgpermissions/orgpermissions.go
@@ -44,8 +44,6 @@ func NewOrgPermissions(config OrgPermissionsConfig) (*OrgPermissions, error) {
 			},
 			Resources: resources,
 
-			// Name is used to compute finalizer names. This here results in something
-			// like operatorkit.giantswarm.io/rbac-operator-RBAC-controller.
 			Name: project.Name() + "-orgpermissions-controller",
 		}
 

--- a/service/controller/orgpermissions/orgpermissions.go
+++ b/service/controller/orgpermissions/orgpermissions.go
@@ -28,7 +28,7 @@ func NewOrgPermissions(config OrgPermissionsConfig) (*OrgPermissions, error) {
 	{
 		c := orgPermissionsResourcesConfig(config)
 
-		resources, err = NewOrgPermissionsResources(c)
+		resources, err = newOrgPermissionsResources(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/service/controller/orgpermissions/orgpermissions_resources.go
+++ b/service/controller/orgpermissions/orgpermissions_resources.go
@@ -16,7 +16,7 @@ type orgPermissionsResourcesConfig struct {
 	Logger    micrologger.Logger
 }
 
-func NewOrgPermissionsResources(config orgPermissionsResourcesConfig) ([]resource.Interface, error) {
+func newOrgPermissionsResources(config orgPermissionsResourcesConfig) ([]resource.Interface, error) {
 	var err error
 
 	var membershipResource resource.Interface

--- a/service/controller/orgpermissions/orgpermissions_resources.go
+++ b/service/controller/orgpermissions/orgpermissions_resources.go
@@ -1,0 +1,60 @@
+package orgpermissions
+
+import (
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/v2/pkg/resource"
+	"github.com/giantswarm/operatorkit/v2/pkg/resource/wrapper/metricsresource"
+	"github.com/giantswarm/operatorkit/v2/pkg/resource/wrapper/retryresource"
+
+	"github.com/giantswarm/rbac-operator/service/controller/orgpermissions/resource/membership"
+)
+
+type orgPermissionsResourcesConfig struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+}
+
+func NewOrgPermissionsResources(config orgPermissionsResourcesConfig) ([]resource.Interface, error) {
+	var err error
+
+	var membershipResource resource.Interface
+	{
+		c := membership.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		membershipResource, err = membership.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []resource.Interface{
+		membershipResource,
+	}
+
+	{
+		c := retryresource.WrapConfig{
+			Logger: config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{}
+
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resources, nil
+}

--- a/service/controller/orgpermissions/resource/membership/create.go
+++ b/service/controller/orgpermissions/resource/membership/create.go
@@ -1,0 +1,17 @@
+package membership
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	/*
+		var err error
+
+			roleBinding, err := key.ToRoleBinding(obj)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+	*/
+	return nil
+}

--- a/service/controller/orgpermissions/resource/membership/create.go
+++ b/service/controller/orgpermissions/resource/membership/create.go
@@ -2,16 +2,26 @@ package membership
 
 import (
 	"context"
+
+	"github.com/giantswarm/microerror"
+	pkgkey "github.com/giantswarm/rbac-operator/pkg/key"
+	"github.com/giantswarm/rbac-operator/service/controller/orgpermissions/key"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	/*
-		var err error
+	var err error
 
-			roleBinding, err := key.ToRoleBinding(obj)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-	*/
+	roleBinding, err := key.ToRoleBinding(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if !pkgkey.IsOrgNamespace(roleBinding.Namespace) || !isTargetRoleBinding(roleBinding) {
+		return nil
+	}
+
+	// 1. create role to get this organization
+	// 2. create rolebinding with copy of subjects
+
 	return nil
 }

--- a/service/controller/orgpermissions/resource/membership/create.go
+++ b/service/controller/orgpermissions/resource/membership/create.go
@@ -2,10 +2,16 @@ package membership
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/giantswarm/microerror"
 	pkgkey "github.com/giantswarm/rbac-operator/pkg/key"
+	"github.com/giantswarm/rbac-operator/pkg/label"
+	"github.com/giantswarm/rbac-operator/pkg/project"
 	"github.com/giantswarm/rbac-operator/service/controller/orgpermissions/key"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
@@ -20,8 +26,46 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return nil
 	}
 
-	// 1. create role to get this organization
-	// 2. create rolebinding with copy of subjects
+	orgReadRoleBindingName := pkgkey.OrganizationReadRoleBindingName(roleBinding.Name)
+	orgReadClusterRoleName := pkgkey.OrganizationReadClusterRoleName(roleBinding.Namespace)
+
+	orgReadRoleBinding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: orgReadRoleBindingName,
+			Labels: map[string]string{
+				label.ManagedBy: project.Name(),
+			},
+		},
+		Subjects: roleBinding.Subjects,
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     orgReadClusterRoleName,
+		},
+	}
+
+	_, err = r.k8sClient.RbacV1().RoleBindings(roleBinding.Namespace).Get(ctx, orgReadRoleBinding.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating rolebinding %#q", orgReadRoleBinding.Name))
+
+		_, err := r.k8sClient.RbacV1().RoleBindings(roleBinding.Namespace).Create(ctx, orgReadRoleBinding, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			// do nothing
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("rolebinding %#q has been created", orgReadRoleBinding.Name))
+
+	} else if err != nil {
+		return microerror.Mask(err)
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("rolebinding %#q already exists", orgReadRoleBinding.Name))
+	}
 
 	return nil
 }

--- a/service/controller/orgpermissions/resource/membership/delete.go
+++ b/service/controller/orgpermissions/resource/membership/delete.go
@@ -1,0 +1,9 @@
+package membership
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/orgpermissions/resource/membership/delete.go
+++ b/service/controller/orgpermissions/resource/membership/delete.go
@@ -2,8 +2,52 @@ package membership
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	pkgkey "github.com/giantswarm/rbac-operator/pkg/key"
+	"github.com/giantswarm/rbac-operator/service/controller/orgpermissions/key"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	var err error
+
+	roleBinding, err := key.ToRoleBinding(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if !pkgkey.IsOrgNamespace(roleBinding.Namespace) || !isTargetRoleBinding(roleBinding) {
+		return nil
+	}
+
+	roleBindingsToDelete := []string{
+		pkgkey.OrganizationReadRoleBindingName(roleBinding.Name),
+	}
+
+	for _, rb := range roleBindingsToDelete {
+
+		_, err = r.k8sClient.RbacV1().RoleBindings(roleBinding.Namespace).Get(ctx, rb, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			// do nothing
+		} else if err != nil {
+			return microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %#q role binding", rb))
+
+			err = r.k8sClient.RbacV1().RoleBindings(roleBinding.Namespace).Delete(ctx, rb, metav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+				// do nothing
+			}
+			if err != nil {
+				return microerror.Mask(err)
+			} else {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("role binding %#q has been deleted", rb))
+			}
+		}
+	}
+
 	return nil
 }

--- a/service/controller/orgpermissions/resource/membership/error.go
+++ b/service/controller/orgpermissions/resource/membership/error.go
@@ -1,0 +1,14 @@
+package membership
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/orgpermissions/resource/membership/resource.go
+++ b/service/controller/orgpermissions/resource/membership/resource.go
@@ -1,0 +1,43 @@
+package membership
+
+import (
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "membership"
+)
+
+type Config struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient: config.K8sClient.K8sClient(),
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/orgpermissions/resource/membership/resource.go
+++ b/service/controller/orgpermissions/resource/membership/resource.go
@@ -4,6 +4,7 @@ import (
 	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	"k8s.io/client-go/kubernetes"
 )
@@ -40,4 +41,13 @@ func New(config Config) (*Resource, error) {
 
 func (r *Resource) Name() string {
 	return Name
+}
+
+func isTargetRoleBinding(roleBinding rbacv1.RoleBinding) bool {
+	for _, subject := range roleBinding.Subjects {
+		if (subject.Kind == "Group" || subject.Kind == "User") && subject.Name != "" {
+			return true
+		}
+	}
+	return false
 }

--- a/service/controller/orgpermissions/resource/membership/resource.go
+++ b/service/controller/orgpermissions/resource/membership/resource.go
@@ -4,6 +4,8 @@ import (
 	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/rbac-operator/pkg/label"
+	"github.com/giantswarm/rbac-operator/pkg/project"
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	"k8s.io/client-go/kubernetes"
@@ -44,6 +46,11 @@ func (r *Resource) Name() string {
 }
 
 func isTargetRoleBinding(roleBinding rbacv1.RoleBinding) bool {
+	managedByLabel, hasManagedByLabel := roleBinding.Labels[label.ManagedBy]
+	if hasManagedByLabel && managedByLabel == project.Name() {
+		return false
+	}
+
 	for _, subject := range roleBinding.Subjects {
 		if (subject.Kind == "Group" || subject.Kind == "User") && subject.Name != "" {
 			return true

--- a/service/controller/rbac/resource/namespaceauth/delete.go
+++ b/service/controller/rbac/resource/namespaceauth/delete.go
@@ -18,48 +18,55 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	roles := []string{
+	clusterRoles := []string{
+		pkgkey.OrganizationReadClusterRoleName(ns.Name),
+	}
+
+	for _, clusterRole := range clusterRoles {
+
+		_, err = r.k8sClient.RbacV1().ClusterRoles().Get(ctx, clusterRole, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			// do nothing
+		} else if err != nil {
+			return microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %#q clusterrole", clusterRole))
+
+			err = r.k8sClient.RbacV1().ClusterRoles().Delete(ctx, clusterRole, metav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+				// do nothing
+			}
+			if err != nil {
+				return microerror.Mask(err)
+			} else {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrole %#q has been deleted", clusterRole))
+			}
+		}
+	}
+
+	roleBindings := []string{
 		pkgkey.WriteAllCustomerGroupRoleBindingName(),
 		pkgkey.WriteAllAutomationSARoleBindingName(),
 	}
 
-	for _, role := range roles {
+	for _, roleBinding := range roleBindings {
 
-		_, err = r.k8sClient.RbacV1().RoleBindings(ns.Name).Get(ctx, role, metav1.GetOptions{})
+		_, err = r.k8sClient.RbacV1().RoleBindings(ns.Name).Get(ctx, roleBinding, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			// do nothing
 		} else if err != nil {
 			return microerror.Mask(err)
 		} else {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %#q role binding", role))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %#q role binding", roleBinding))
 
-			err = r.k8sClient.RbacV1().RoleBindings(ns.Name).Delete(ctx, role, metav1.DeleteOptions{})
+			err = r.k8sClient.RbacV1().RoleBindings(ns.Name).Delete(ctx, roleBinding, metav1.DeleteOptions{})
 			if apierrors.IsNotFound(err) {
 				// do nothing
 			}
 			if err != nil {
 				return microerror.Mask(err)
 			} else {
-				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("role binding %#q has been deleted", role))
-			}
-		}
-
-		_, err = r.k8sClient.RbacV1().Roles(ns.Name).Get(ctx, role, metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			// do nothing
-		} else if err != nil {
-			return microerror.Mask(err)
-		} else {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %#q role", role))
-
-			err = r.k8sClient.RbacV1().Roles(ns.Name).Delete(ctx, role, metav1.DeleteOptions{})
-			if apierrors.IsNotFound(err) {
-				// do nothing
-			}
-			if err != nil {
-				return microerror.Mask(err)
-			} else {
-				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("role %#q has been deleted", role))
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("role binding %#q has been deleted", roleBinding))
 			}
 		}
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/giantswarm/rbac-operator/flag"
 	"github.com/giantswarm/rbac-operator/pkg/project"
 	"github.com/giantswarm/rbac-operator/service/collector"
+	"github.com/giantswarm/rbac-operator/service/controller/orgpermissions"
 	"github.com/giantswarm/rbac-operator/service/controller/rbac"
 	"github.com/giantswarm/rbac-operator/service/internal/bootstrap"
 )
@@ -32,10 +33,11 @@ type Config struct {
 type Service struct {
 	Version *version.Service
 
-	bootOnce          sync.Once
-	bootstrapRunner   *bootstrap.Bootstrap
-	rbacController    *rbac.RBAC
-	operatorCollector *collector.Set
+	bootOnce                 sync.Once
+	bootstrapRunner          *bootstrap.Bootstrap
+	rbacController           *rbac.RBAC
+	orgPermissionsController *orgpermissions.OrgPermissions
+	operatorCollector        *collector.Set
 }
 
 // New creates a new configured service object.
@@ -127,6 +129,20 @@ func New(config Config) (*Service, error) {
 		}
 	}
 
+	var orgPermissionsController *orgpermissions.OrgPermissions
+	{
+
+		c := orgpermissions.OrgPermissionsConfig{
+			K8sClient: k8sClient,
+			Logger:    config.Logger,
+		}
+
+		orgPermissionsController, err = orgpermissions.NewOrgPermissions(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var operatorCollector *collector.Set
 	{
 		c := collector.SetConfig{
@@ -159,10 +175,11 @@ func New(config Config) (*Service, error) {
 	s := &Service{
 		Version: versionService,
 
-		bootOnce:          sync.Once{},
-		bootstrapRunner:   bootstrapRunner,
-		rbacController:    rbacController,
-		operatorCollector: operatorCollector,
+		bootOnce:                 sync.Once{},
+		bootstrapRunner:          bootstrapRunner,
+		rbacController:           rbacController,
+		orgPermissionsController: orgPermissionsController,
+		operatorCollector:        operatorCollector,
 	}
 
 	return s, nil
@@ -179,5 +196,7 @@ func (s *Service) Boot(ctx context.Context) {
 		go s.operatorCollector.Boot(ctx)
 
 		go s.rbacController.Boot(ctx)
+
+		go s.orgPermissionsController.Boot(ctx)
 	})
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16060

1. For every organization namespace, there is clusterrole with name `<org>-organization-read` created with the following access:

```
rules:
- apiGroups:
  - security.giantswarm.io
  resourceNames:
  - <org>
  resources:
  - organizations
  verbs:
  - get
```

2. For every rolebinding in organization namespace, where subject is Group or User, new rolebinding with name `<source binding>-organization-read` is created, where subjects are the same as in orgininal rolebinding and clusterrole is from *1*

## Checklist

- [ ] Update changelog in CHANGELOG.md.
