### PR TITLE
Allow automation to edit flux and cluster-specific CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Provide access to the customer automation SA for managing flux resources.
+
 ## [0.16.0] - 2021-10-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Provide access to the customer automation SA for managing flux resources.
 - Provide access to the customer automation SA for managing cluster-specific resources.
+- Provide access to the customer automation SA for managing node pool-specific resources.
 
 ## [0.16.0] - 2021-10-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Provide access to the customer automation SA for managing flux resources.
+- Provide access to the customer automation SA for managing cluster-specific resources.
 
 ## [0.16.0] - 2021-10-07
 

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -14,6 +14,7 @@ const (
 	WriteOrganizationsPermissionsName = "write-organizations"
 	WriteFluxResourcesPermissionsName = "write-flux-resources"
 	WriteClustersPermissionsName      = "write-clusters"
+	WriteNodePoolsPermissionsName     = "write-nodepools"
 )
 
 func DefaultClusterRolesToDisplayInUI() []string {
@@ -72,4 +73,8 @@ func WriteFluxResourcesAutomationSARoleBindingName() string {
 
 func WriteClustersAutomationSARoleBindingName() string {
 	return fmt.Sprintf("%s-customer-sa", WriteClustersPermissionsName)
+}
+
+func WriteNodePoolsAutomationSARoleBindingName() string {
+	return fmt.Sprintf("%s-customer-sa", WriteNodePoolsPermissionsName)
 }

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -12,6 +12,7 @@ const (
 	DefaultWriteAllPermissionsName    = "write-all"
 	DefaultNamespaceName              = "default"
 	WriteOrganizationsPermissionsName = "write-organizations"
+	WriteFluxResourcesPermissionsName = "write-flux-resources"
 )
 
 func DefaultClusterRolesToDisplayInUI() []string {
@@ -62,4 +63,8 @@ func WriteAllGSGroupClusterRoleBindingName() string {
 
 func WriteOrganizationsCustomerGroupClusterRoleBindingName() string {
 	return fmt.Sprintf("%s-customer-group", WriteOrganizationsPermissionsName)
+}
+
+func WriteFluxResourcesAutomationSARoleBindingName() string {
+	return fmt.Sprintf("%s-customer-sa", WriteFluxResourcesPermissionsName)
 }

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -13,6 +13,7 @@ const (
 	DefaultNamespaceName              = "default"
 	WriteOrganizationsPermissionsName = "write-organizations"
 	WriteFluxResourcesPermissionsName = "write-flux-resources"
+	WriteClustersPermissionsName      = "write-clusters"
 )
 
 func DefaultClusterRolesToDisplayInUI() []string {
@@ -67,4 +68,8 @@ func WriteOrganizationsCustomerGroupClusterRoleBindingName() string {
 
 func WriteFluxResourcesAutomationSARoleBindingName() string {
 	return fmt.Sprintf("%s-customer-sa", WriteFluxResourcesPermissionsName)
+}
+
+func WriteClustersAutomationSARoleBindingName() string {
+	return fmt.Sprintf("%s-customer-sa", WriteClustersPermissionsName)
 }

--- a/service/internal/bootstrap/bootstrap.go
+++ b/service/internal/bootstrap/bootstrap.go
@@ -107,6 +107,16 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		return microerror.Mask(err)
 	}
 
+	err = b.createWriteFluxResourcesClusterRole(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = b.createWriteFluxResourcesClusterRoleBindingToAutomationSA(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	err = b.labelDefaultClusterRoles(ctx)
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/internal/bootstrap/bootstrap.go
+++ b/service/internal/bootstrap/bootstrap.go
@@ -117,6 +117,16 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		return microerror.Mask(err)
 	}
 
+	err = b.createWriteClustersClusterRole(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = b.createWriteClustersClusterRoleBindingToAutomationSA(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	err = b.labelDefaultClusterRoles(ctx)
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/internal/bootstrap/bootstrap.go
+++ b/service/internal/bootstrap/bootstrap.go
@@ -127,6 +127,16 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		return microerror.Mask(err)
 	}
 
+	err = b.createWriteNodePoolsClusterRole(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = b.createWriteNodePoolsClusterRoleBindingToAutomationSA(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	err = b.labelDefaultClusterRoles(ctx)
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/internal/bootstrap/resources.go
+++ b/service/internal/bootstrap/resources.go
@@ -663,6 +663,108 @@ func (b *Bootstrap) createWriteFluxResourcesClusterRoleBindingToAutomationSA(ctx
 	return nil
 }
 
+func (b *Bootstrap) createWriteClustersClusterRole(ctx context.Context) error {
+	policyRule := rbacv1.PolicyRule{
+		APIGroups: []string{"cluster.x-k8s.io", "infrastructure.cluster.x-k8s.io", "infrastructure.giantswarm.io"},
+		Resources: []string{"clusters", "awsclusters", "awscontrolplanes", "g8scontrolplanes", "azureclusters", "azuremachines"},
+		Verbs:     []string{"*"},
+	}
+
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: key.WriteClustersPermissionsName,
+			Labels: map[string]string{
+				label.ManagedBy:              project.Name(),
+				label.DisplayInUserInterface: "true",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{policyRule},
+	}
+
+	_, err := b.k8sClient.RbacV1().ClusterRoles().Get(ctx, clusterRole.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating clusterrole %#q", clusterRole.Name))
+
+		_, err := b.k8sClient.RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			// Do nothing.
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrole %#q has been created", clusterRole.Name))
+
+	} else if err != nil {
+		return microerror.Mask(err)
+	} else {
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating clusterrole binding %#q", clusterRole.Name))
+		_, err := b.k8sClient.RbacV1().ClusterRoles().Update(ctx, clusterRole, metav1.UpdateOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrole %#q has been updated", clusterRole.Name))
+	}
+
+	return nil
+}
+
+func (b *Bootstrap) createWriteClustersClusterRoleBindingToAutomationSA(ctx context.Context) error {
+	clusterRoleBindingName := key.WriteClustersAutomationSARoleBindingName()
+
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterRoleBindingName,
+			Labels: map[string]string{
+				label.ManagedBy: project.Name(),
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      key.AutomationServiceAccountName,
+				Namespace: key.DefaultNamespaceName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     key.WriteClustersPermissionsName,
+		},
+	}
+
+	_, err := b.k8sClient.RbacV1().ClusterRoleBindings().Get(ctx, clusterRoleBinding.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating clusterrolebinding %#q", clusterRoleBinding.Name))
+
+		_, err = b.k8sClient.RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			// Do nothing.
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrolebinding %#q has been created", clusterRoleBinding.Name))
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating clusterrolebinding %#q", clusterRoleBinding.Name))
+
+	_, err = b.k8sClient.RbacV1().ClusterRoleBindings().Update(ctx, clusterRoleBinding, metav1.UpdateOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrolebinding %#q has been updated", clusterRoleBinding.Name))
+
+	return nil
+}
+
 // Grant cluster-admin access for automation service account to default namespace.
 func (b *Bootstrap) labelDefaultClusterRoles(ctx context.Context) error {
 	clusterRoles := key.DefaultClusterRolesToDisplayInUI()

--- a/service/internal/bootstrap/resources.go
+++ b/service/internal/bootstrap/resources.go
@@ -765,6 +765,108 @@ func (b *Bootstrap) createWriteClustersClusterRoleBindingToAutomationSA(ctx cont
 	return nil
 }
 
+func (b *Bootstrap) createWriteNodePoolsClusterRole(ctx context.Context) error {
+	policyRule := rbacv1.PolicyRule{
+		APIGroups: []string{"cluster.x-k8s.io", "exp.cluster.x-k8s.io", "infrastructure.cluster.x-k8s.io", "infrastructure.giantswarm.io", "core.giantswarm.io"},
+		Resources: []string{"machinedeployments", "awsmachinedeployments", "networkpools", "machinepools", "azuremachinepools", "sparks"},
+		Verbs:     []string{"*"},
+	}
+
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: key.WriteNodePoolsPermissionsName,
+			Labels: map[string]string{
+				label.ManagedBy:              project.Name(),
+				label.DisplayInUserInterface: "true",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{policyRule},
+	}
+
+	_, err := b.k8sClient.RbacV1().ClusterRoles().Get(ctx, clusterRole.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating clusterrole %#q", clusterRole.Name))
+
+		_, err := b.k8sClient.RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			// Do nothing.
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrole %#q has been created", clusterRole.Name))
+
+	} else if err != nil {
+		return microerror.Mask(err)
+	} else {
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating clusterrole binding %#q", clusterRole.Name))
+		_, err := b.k8sClient.RbacV1().ClusterRoles().Update(ctx, clusterRole, metav1.UpdateOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrole %#q has been updated", clusterRole.Name))
+	}
+
+	return nil
+}
+
+func (b *Bootstrap) createWriteNodePoolsClusterRoleBindingToAutomationSA(ctx context.Context) error {
+	clusterRoleBindingName := key.WriteNodePoolsAutomationSARoleBindingName()
+
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterRoleBindingName,
+			Labels: map[string]string{
+				label.ManagedBy: project.Name(),
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      key.AutomationServiceAccountName,
+				Namespace: key.DefaultNamespaceName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     key.WriteNodePoolsPermissionsName,
+		},
+	}
+
+	_, err := b.k8sClient.RbacV1().ClusterRoleBindings().Get(ctx, clusterRoleBinding.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating clusterrolebinding %#q", clusterRoleBinding.Name))
+
+		_, err = b.k8sClient.RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			// Do nothing.
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrolebinding %#q has been created", clusterRoleBinding.Name))
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating clusterrolebinding %#q", clusterRoleBinding.Name))
+
+	_, err = b.k8sClient.RbacV1().ClusterRoleBindings().Update(ctx, clusterRoleBinding, metav1.UpdateOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrolebinding %#q has been updated", clusterRoleBinding.Name))
+
+	return nil
+}
+
 // Grant cluster-admin access for automation service account to default namespace.
 func (b *Bootstrap) labelDefaultClusterRoles(ctx context.Context) error {
 	clusterRoles := key.DefaultClusterRolesToDisplayInUI()

--- a/service/internal/bootstrap/resources.go
+++ b/service/internal/bootstrap/resources.go
@@ -561,6 +561,108 @@ func (b *Bootstrap) createWriteOrganizationsClusterRoleBindingToAutomationSA(ctx
 	return nil
 }
 
+func (b *Bootstrap) createWriteFluxResourcesClusterRole(ctx context.Context) error {
+	policyRule := rbacv1.PolicyRule{
+		APIGroups: []string{"notification.toolkit.fluxcd.io", "source.toolkit.fluxcd.io", "image.toolkit.fluxcd.io", "helm.toolkit.fluxcd.io", "kustomizations.kustomize.toolkit.fluxcd.io"},
+		Resources: []string{"alerts", "providers", "receivers", "buckets", "gitrepositories", "helmcharts", "helmrepositories", "imagepolicies", "imagerepositories", "imageupdateautomations", "helmreleases", "kustomizations"},
+		Verbs:     []string{"*"},
+	}
+
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: key.WriteFluxResourcesPermissionsName,
+			Labels: map[string]string{
+				label.ManagedBy:              project.Name(),
+				label.DisplayInUserInterface: "true",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{policyRule},
+	}
+
+	_, err := b.k8sClient.RbacV1().ClusterRoles().Get(ctx, clusterRole.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating clusterrole %#q", clusterRole.Name))
+
+		_, err := b.k8sClient.RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			// Do nothing.
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrole %#q has been created", clusterRole.Name))
+
+	} else if err != nil {
+		return microerror.Mask(err)
+	} else {
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating clusterrole binding %#q", clusterRole.Name))
+		_, err := b.k8sClient.RbacV1().ClusterRoles().Update(ctx, clusterRole, metav1.UpdateOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrole %#q has been updated", clusterRole.Name))
+	}
+
+	return nil
+}
+
+func (b *Bootstrap) createWriteFluxResourcesClusterRoleBindingToAutomationSA(ctx context.Context) error {
+	clusterRoleBindingName := key.WriteFluxResourcesAutomationSARoleBindingName()
+
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterRoleBindingName,
+			Labels: map[string]string{
+				label.ManagedBy: project.Name(),
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      key.AutomationServiceAccountName,
+				Namespace: key.DefaultNamespaceName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     key.WriteFluxResourcesPermissionsName,
+		},
+	}
+
+	_, err := b.k8sClient.RbacV1().ClusterRoleBindings().Get(ctx, clusterRoleBinding.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating clusterrolebinding %#q", clusterRoleBinding.Name))
+
+		_, err = b.k8sClient.RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			// Do nothing.
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrolebinding %#q has been created", clusterRoleBinding.Name))
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating clusterrolebinding %#q", clusterRoleBinding.Name))
+
+	_, err = b.k8sClient.RbacV1().ClusterRoleBindings().Update(ctx, clusterRoleBinding, metav1.UpdateOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrolebinding %#q has been updated", clusterRoleBinding.Name))
+
+	return nil
+}
+
 // Grant cluster-admin access for automation service account to default namespace.
 func (b *Bootstrap) labelDefaultClusterRoles(ctx context.Context) error {
 	clusterRoles := key.DefaultClusterRolesToDisplayInUI()


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/534

Turns out the customer asked for access to more CRs than I initially thought. So we have all the `flux` resources, as well as all cluster and node pool specific resources.