### PR TITLE
Add permission for WC cert creation to the automation SA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Provide access to the customer automation SA for managing workload cluster client certificates.
+
 ## [0.17.0] - 2021-11-04
 
 ### Added

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -15,6 +15,7 @@ const (
 	WriteFluxResourcesPermissionsName = "write-flux-resources"
 	WriteClustersPermissionsName      = "write-clusters"
 	WriteNodePoolsPermissionsName     = "write-nodepools"
+	WriteClientCertsPermissionsName   = "write-client-certificates"
 )
 
 func DefaultClusterRolesToDisplayInUI() []string {
@@ -77,4 +78,8 @@ func WriteClustersAutomationSARoleBindingName() string {
 
 func WriteNodePoolsAutomationSARoleBindingName() string {
 	return fmt.Sprintf("%s-customer-sa", WriteNodePoolsPermissionsName)
+}
+
+func WriteClientCertsAutomationSARoleBindingName() string {
+	return fmt.Sprintf("%s-customer-sa", WriteClientCertsPermissionsName)
 }

--- a/service/internal/bootstrap/resources.go
+++ b/service/internal/bootstrap/resources.go
@@ -867,6 +867,108 @@ func (b *Bootstrap) createWriteNodePoolsClusterRoleBindingToAutomationSA(ctx con
 	return nil
 }
 
+func (b *Bootstrap) createWriteClientCertsClusterRole(ctx context.Context) error {
+	policyRule := rbacv1.PolicyRule{
+		APIGroups: []string{"core.giantswarm.io"},
+		Resources: []string{"certconfigs"},
+		Verbs:     []string{"*"},
+	}
+
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: key.WriteClientCertsPermissionsName,
+			Labels: map[string]string{
+				label.ManagedBy:              project.Name(),
+				label.DisplayInUserInterface: "true",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{policyRule},
+	}
+
+	_, err := b.k8sClient.RbacV1().ClusterRoles().Get(ctx, clusterRole.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating clusterrole %#q", clusterRole.Name))
+
+		_, err := b.k8sClient.RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			// Do nothing.
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrole %#q has been created", clusterRole.Name))
+
+	} else if err != nil {
+		return microerror.Mask(err)
+	} else {
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating clusterrole binding %#q", clusterRole.Name))
+		_, err := b.k8sClient.RbacV1().ClusterRoles().Update(ctx, clusterRole, metav1.UpdateOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrole %#q has been updated", clusterRole.Name))
+	}
+
+	return nil
+}
+
+func (b *Bootstrap) createWriteClientCertsClusterRoleBindingToAutomationSA(ctx context.Context) error {
+	clusterRoleBindingName := key.WriteClientCertsAutomationSARoleBindingName()
+
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterRoleBindingName,
+			Labels: map[string]string{
+				label.ManagedBy: project.Name(),
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      key.AutomationServiceAccountName,
+				Namespace: key.DefaultNamespaceName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     key.WriteClientCertsPermissionsName,
+		},
+	}
+
+	_, err := b.k8sClient.RbacV1().ClusterRoleBindings().Get(ctx, clusterRoleBinding.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating clusterrolebinding %#q", clusterRoleBinding.Name))
+
+		_, err = b.k8sClient.RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			// Do nothing.
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrolebinding %#q has been created", clusterRoleBinding.Name))
+
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating clusterrolebinding %#q", clusterRoleBinding.Name))
+
+	_, err = b.k8sClient.RbacV1().ClusterRoleBindings().Update(ctx, clusterRoleBinding, metav1.UpdateOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	b.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrolebinding %#q has been updated", clusterRoleBinding.Name))
+
+	return nil
+}
+
 // Grant cluster-admin access for automation service account to default namespace.
 func (b *Bootstrap) labelDefaultClusterRoles(ctx context.Context) error {
 	clusterRoles := key.DefaultClusterRolesToDisplayInUI()


### PR DESCRIPTION
Customers need to be able to create WC client certificates using the `automation` ServiceAccount.