### PR TITLE
Add user-friendly descriptions to ClusterRole resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add user-friendly descriptions to created `ClusterRole` resources, via annotations using the `ui.giantswarm.io/description` key.
+
 ## [0.18.4] - 2021-12-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add user-friendly descriptions to created `ClusterRole` resources, via annotations using the `ui.giantswarm.io/description` key.
+- Add user-friendly descriptions to created `ClusterRole` resources, via annotations using the `giantswarm.io/notes` key.
 
 ## [0.18.4] - 2021-12-10
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/giantswarm/apiextensions/v3 v3.39.0
 	github.com/giantswarm/exporterkit v0.2.1
 	github.com/giantswarm/k8sclient/v5 v5.12.0
+	github.com/giantswarm/k8smetadata v0.7.1
 	github.com/giantswarm/microendpoint v0.2.0
 	github.com/giantswarm/microerror v0.3.0
 	github.com/giantswarm/microkit v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/giantswarm/exporterkit v0.2.1/go.mod h1:LkZNK+2qTcbHspbizA6JBBXpQW99u
 github.com/giantswarm/k8sclient/v5 v5.10.0/go.mod h1:HHSHvERGfLhNqTsqKBUQSQ5VXGhLfVRojplYwio6jDU=
 github.com/giantswarm/k8sclient/v5 v5.12.0 h1:oG5k7LLqMT+OaR/jMqOAQMTCpv5OdwjcJhFYGdIPThQ=
 github.com/giantswarm/k8sclient/v5 v5.12.0/go.mod h1:KXRSG1t+XBDsXx089Jp9agMjQ4xEIWywJUchAZ2OQ6c=
+github.com/giantswarm/k8smetadata v0.7.1 h1:Wc49mhisTc1BgaDGEPtnP7VCozuoa3DI/Txx4p++sdo=
+github.com/giantswarm/k8smetadata v0.7.1/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/microendpoint v0.2.0 h1:xCAqAVRjTw/4ifEuBeNavALdbQsLk6+k/ukzdy0GWZE=
 github.com/giantswarm/microendpoint v0.2.0/go.mod h1:SSkSp4Q4iSW7vwkil+/E3IXy9Q8To8vXmT5VCg24RDg=
 github.com/giantswarm/microerror v0.2.0/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=

--- a/service/internal/bootstrap/resources.go
+++ b/service/internal/bootstrap/resources.go
@@ -19,6 +19,10 @@ import (
 	"github.com/giantswarm/rbac-operator/pkg/project"
 )
 
+const (
+	descriptionAnnotationKey string = "ui.giantswarm.io/description"
+)
+
 // Ensures the 'automation' service account in the default namespace.
 func (b *Bootstrap) createAutomationServiceAccount(ctx context.Context) error {
 
@@ -106,6 +110,9 @@ func (b *Bootstrap) createReadAllClusterRole(ctx context.Context) error {
 				label.ManagedBy:              project.Name(),
 				label.DisplayInUserInterface: "true",
 			},
+			Annotations: map[string]string{
+				descriptionAnnotationKey: "Grants read-only (get, list, watch) permissions to almost all resource types known on the management cluster, with exception of ConfigMap and Secret.",
+			},
 		},
 		Rules: policyRules,
 	}
@@ -155,6 +162,9 @@ func (b *Bootstrap) createWriteOrganizationsClusterRole(ctx context.Context) err
 			Labels: map[string]string{
 				label.ManagedBy:              project.Name(),
 				label.DisplayInUserInterface: "true",
+			},
+			Annotations: map[string]string{
+				descriptionAnnotationKey: "Grants full permissions for the organizations.security.giantswarm.io resource type.",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{policyRule},
@@ -619,6 +629,9 @@ func (b *Bootstrap) createWriteFluxResourcesClusterRole(ctx context.Context) err
 				label.ManagedBy:              project.Name(),
 				label.DisplayInUserInterface: "true",
 			},
+			Annotations: map[string]string{
+				descriptionAnnotationKey: "Grants full permissions to FluxCD related resource types.",
+			},
 		},
 		Rules: []rbacv1.PolicyRule{policyRule},
 	}
@@ -738,6 +751,9 @@ func (b *Bootstrap) createWriteClustersClusterRole(ctx context.Context) error {
 			Labels: map[string]string{
 				label.ManagedBy:              project.Name(),
 				label.DisplayInUserInterface: "true",
+			},
+			Annotations: map[string]string{
+				descriptionAnnotationKey: "Grants full permissions to resources for clusters, excluding node pools.",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{policyRule},
@@ -860,6 +876,9 @@ func (b *Bootstrap) createWriteNodePoolsClusterRole(ctx context.Context) error {
 				label.ManagedBy:              project.Name(),
 				label.DisplayInUserInterface: "true",
 			},
+			Annotations: map[string]string{
+				descriptionAnnotationKey: "Grants full permissions on resources representing node pools.",
+			},
 		},
 		Rules: []rbacv1.PolicyRule{policyRule},
 	}
@@ -975,6 +994,9 @@ func (b *Bootstrap) createWriteClientCertsClusterRole(ctx context.Context) error
 				label.ManagedBy:              project.Name(),
 				label.DisplayInUserInterface: "true",
 			},
+			Annotations: map[string]string{
+				descriptionAnnotationKey: "Grants full permissions on certconfigs.core.giantswarm.io resources.",
+			},
 		},
 		Rules: []rbacv1.PolicyRule{policyRule},
 	}
@@ -1086,6 +1108,9 @@ func (b *Bootstrap) createWriteSilencesClusterRole(ctx context.Context) error {
 			Labels: map[string]string{
 				label.ManagedBy:              project.Name(),
 				label.DisplayInUserInterface: "true",
+			},
+			Annotations: map[string]string{
+				descriptionAnnotationKey: "Grants full permissions for silences.monitoring.giantswarm.io resources.",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{policyRule},

--- a/service/internal/bootstrap/resources.go
+++ b/service/internal/bootstrap/resources.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -17,10 +18,6 @@ import (
 
 	"github.com/giantswarm/rbac-operator/pkg/key"
 	"github.com/giantswarm/rbac-operator/pkg/project"
-)
-
-const (
-	descriptionAnnotationKey string = "ui.giantswarm.io/description"
 )
 
 // Ensures the 'automation' service account in the default namespace.
@@ -111,7 +108,7 @@ func (b *Bootstrap) createReadAllClusterRole(ctx context.Context) error {
 				label.DisplayInUserInterface: "true",
 			},
 			Annotations: map[string]string{
-				descriptionAnnotationKey: "Grants read-only (get, list, watch) permissions to almost all resource types known on the management cluster, with exception of ConfigMap and Secret.",
+				annotation.Notes: "Grants read-only (get, list, watch) permissions to almost all resource types known on the management cluster, with exception of ConfigMap and Secret.",
 			},
 		},
 		Rules: policyRules,
@@ -164,7 +161,7 @@ func (b *Bootstrap) createWriteOrganizationsClusterRole(ctx context.Context) err
 				label.DisplayInUserInterface: "true",
 			},
 			Annotations: map[string]string{
-				descriptionAnnotationKey: "Grants full permissions for the organizations.security.giantswarm.io resource type.",
+				annotation.Notes: "Grants full permissions for the organizations.security.giantswarm.io resource type.",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{policyRule},
@@ -630,7 +627,7 @@ func (b *Bootstrap) createWriteFluxResourcesClusterRole(ctx context.Context) err
 				label.DisplayInUserInterface: "true",
 			},
 			Annotations: map[string]string{
-				descriptionAnnotationKey: "Grants full permissions to FluxCD related resource types.",
+				annotation.Notes: "Grants full permissions to FluxCD related resource types.",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{policyRule},
@@ -753,7 +750,7 @@ func (b *Bootstrap) createWriteClustersClusterRole(ctx context.Context) error {
 				label.DisplayInUserInterface: "true",
 			},
 			Annotations: map[string]string{
-				descriptionAnnotationKey: "Grants full permissions to resources for clusters, excluding node pools.",
+				annotation.Notes: "Grants full permissions to resources for clusters, excluding node pools.",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{policyRule},
@@ -877,7 +874,7 @@ func (b *Bootstrap) createWriteNodePoolsClusterRole(ctx context.Context) error {
 				label.DisplayInUserInterface: "true",
 			},
 			Annotations: map[string]string{
-				descriptionAnnotationKey: "Grants full permissions on resources representing node pools.",
+				annotation.Notes: "Grants full permissions on resources representing node pools.",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{policyRule},
@@ -995,7 +992,7 @@ func (b *Bootstrap) createWriteClientCertsClusterRole(ctx context.Context) error
 				label.DisplayInUserInterface: "true",
 			},
 			Annotations: map[string]string{
-				descriptionAnnotationKey: "Grants full permissions on certconfigs.core.giantswarm.io resources.",
+				annotation.Notes: "Grants full permissions on certconfigs.core.giantswarm.io resources.",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{policyRule},
@@ -1110,7 +1107,7 @@ func (b *Bootstrap) createWriteSilencesClusterRole(ctx context.Context) error {
 				label.DisplayInUserInterface: "true",
 			},
 			Annotations: map[string]string{
-				descriptionAnnotationKey: "Grants full permissions for silences.monitoring.giantswarm.io resources.",
+				annotation.Notes: "Grants full permissions for silences.monitoring.giantswarm.io resources.",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{policyRule},


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/602

This applies the annotation `giantswarm.io/notes` to created ClusterRole resources, in order to provide user-friendly descriptions for all cluster roles.

## Checklist

- [x] Update changelog in CHANGELOG.md.
