### PR TITLE
Add checklist item to PR template for role description annotation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
 ## Checklist
 
 - [ ] Update changelog in CHANGELOG.md.
+- [ ] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation `giantswarm.io/notes` to help explain their purpose and usage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add user-friendly descriptions to created `ClusterRole` resources, via annotations using the `giantswarm.io/notes` key.
+
 ### Fixed
 
 - Add missing `imagePullSecret`.


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/602.

This PR updates the PR template by adding an item to the checklist as a reminder to add description annotations if the PR introduces new roles.

## Checklist

- [x] Update changelog in CHANGELOG.md.
