### PR TITLE
Add update option for orgReadClusterRoleBinding resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add update option for `orgReadClusterRoleBinding` resource.
+
 ## [0.20.0] - 2022-02-07
 
 ### Added


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/766

## Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation `giantswarm.io/notes` to help explain their purpose and usage.
