### PR TITLE
Improve logging in clusternamespace controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-
 - Add creation of `read-default-catalogs` Role.
 - Add creation of `read-releases` ClusterRole.
+- In the `clusternamespace` controller, remove logging for non-operations and add namespace info to log messages.
 
 ## [0.21.0] - 2022-02-16
 

--- a/service/controller/clusternamespace/resource/clusternamespaceresources/create.go
+++ b/service/controller/clusternamespace/resource/clusternamespaceresources/create.go
@@ -41,12 +41,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	// List roleBindings in org-namespace
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Listing RoleBindings in namespace %s.", orgNamespace))
 	orgRoleBindings, err := r.k8sClient.K8sClient().RbacV1().RoleBindings(orgNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return microerror.Mask(err)
 	} else if len(orgRoleBindings.Items) == 0 {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("No RoleBindings found in namespace %s.", orgNamespace))
 		return nil
 	}
 
@@ -133,7 +131,7 @@ func (r *Resource) ensureClusterNamespaceNSRoleBinding(ctx context.Context, subj
 func (r *Resource) createOrUpdateRole(ctx context.Context, namespace string, role *rbacv1.Role) error {
 	existingRole, err := r.k8sClient.K8sClient().RbacV1().Roles(namespace).Get(ctx, role.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Creating Role %#q.", role.Name))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Creating Role %#q in namespace %s.", role.Name, namespace))
 
 		_, err := r.k8sClient.K8sClient().RbacV1().Roles(namespace).Create(ctx, role, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
@@ -142,20 +140,18 @@ func (r *Resource) createOrUpdateRole(ctx context.Context, namespace string, rol
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Role %#q has been created.", role.Name))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Role %#q has been created.", role.Name))
 
 	} else if err != nil {
 		return microerror.Mask(err)
 	} else if roleNeedsUpdate(role, existingRole) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Updating Role %#q.", role.Name))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Updating Role %#q.", role.Name))
 		_, err := r.k8sClient.K8sClient().RbacV1().Roles(namespace).Update(ctx, role, metav1.UpdateOptions{})
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Role %#q has been updated.", role.Name))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Role %#q has been updated.", role.Name))
 
-	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Role %#q already exists.", role.Name))
 	}
 
 	return nil
@@ -164,7 +160,7 @@ func (r *Resource) createOrUpdateRole(ctx context.Context, namespace string, rol
 func (r *Resource) createOrUpdateRoleBinding(ctx context.Context, namespace string, roleBinding *rbacv1.RoleBinding) error {
 	existingRoleBinding, err := r.k8sClient.K8sClient().RbacV1().RoleBindings(namespace).Get(ctx, roleBinding.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Creating RoleBinding %#q.", roleBinding.Name))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Creating RoleBinding %#q in namespce %s.", roleBinding.Name, namespace))
 
 		_, err := r.k8sClient.K8sClient().RbacV1().RoleBindings(namespace).Create(ctx, roleBinding, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
@@ -173,20 +169,18 @@ func (r *Resource) createOrUpdateRoleBinding(ctx context.Context, namespace stri
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("RoleBinding %#q has been created.", roleBinding.Name))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("RoleBinding %#q in namespace %s has been created.", roleBinding.Name, namespace))
 
 	} else if err != nil {
 		return microerror.Mask(err)
 	} else if roleBindingNeedsUpdate(roleBinding, existingRoleBinding) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Updating RoleBinding %#q.", roleBinding.Name))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Updating RoleBinding %#q in namespace %s.", roleBinding.Name, namespace))
 		_, err := r.k8sClient.K8sClient().RbacV1().RoleBindings(namespace).Update(ctx, roleBinding, metav1.UpdateOptions{})
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("RoleBinding %#q has been updated.", roleBinding.Name))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("RoleBinding %#q in namespace %s has been updated.", roleBinding.Name, namespace))
 
-	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("RoleBinding %#q already exists.", roleBinding.Name))
 	}
 
 	return nil

--- a/service/controller/clusternamespace/resource/clusternamespaceresources/create.go
+++ b/service/controller/clusternamespace/resource/clusternamespaceresources/create.go
@@ -140,17 +140,17 @@ func (r *Resource) createOrUpdateRole(ctx context.Context, namespace string, rol
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Role %#q has been created.", role.Name))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Role %#q in namespace %s has been created.", role.Name, namespace))
 
 	} else if err != nil {
 		return microerror.Mask(err)
 	} else if roleNeedsUpdate(role, existingRole) {
-		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Updating Role %#q.", role.Name))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Updating Role %#q in namespace %s.", role.Name, namespace))
 		_, err := r.k8sClient.K8sClient().RbacV1().Roles(namespace).Update(ctx, role, metav1.UpdateOptions{})
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Role %#q has been updated.", role.Name))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Role %#q in namespace %s has been updated.", role.Name, namespace))
 
 	}
 

--- a/service/controller/clusternamespace/resource/clusternamespaceresources/delete.go
+++ b/service/controller/clusternamespace/resource/clusternamespaceresources/delete.go
@@ -43,7 +43,7 @@ func (r *Resource) deleteRoleBinding(ctx context.Context, namespace string, role
 	} else if err != nil {
 		return microerror.Mask(err)
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Deleting %#q roleBinding.", roleBinding))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Deleting RoleBinding %#q in namespace %s.", roleBinding, namespace))
 
 		err = r.k8sClient.K8sClient().RbacV1().RoleBindings(namespace).Delete(ctx, roleBinding, metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
@@ -51,7 +51,7 @@ func (r *Resource) deleteRoleBinding(ctx context.Context, namespace string, role
 		} else if err != nil {
 			return microerror.Mask(err)
 		}
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("RoleBinding %#q has been deleted.", roleBinding))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("RoleBinding %#q in namespace %s has been deleted.", roleBinding, namespace))
 	}
 	return nil
 }
@@ -65,7 +65,7 @@ func (r *Resource) deleteRole(ctx context.Context, namespace string, role string
 	} else if err != nil {
 		return microerror.Mask(err)
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Deleting %#q role.", role))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Deleting Role %#q in namespace %s.", role, namespace))
 
 		err = r.k8sClient.K8sClient().RbacV1().Roles(namespace).Delete(ctx, role, metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
@@ -73,7 +73,7 @@ func (r *Resource) deleteRole(ctx context.Context, namespace string, role string
 		} else if err != nil {
 			return microerror.Mask(err)
 		}
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Role %#q has been deleted.", role))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Role %#q in namespace %s has been deleted.", role, namespace))
 	}
 	return nil
 }


### PR DESCRIPTION
Draft to illustrate how I would like the controllers to log.

- Don't produce a log line if nothing is done.
- If something is happening, use level `info`.
- Try to make the log messages as useful as possible, e. g. by providing the namespace where it's relevant.

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation `giantswarm.io/notes` to help explain their purpose and usage.
