### PR TITLE
Clean up logging in orgpermissions controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-
 - Add creation of `read-default-catalogs` Role.
 - Add creation of `read-releases` ClusterRole.
+- In the `orgpermissions` controller, remove logging for non-operations and add namespace info to log messages.
 
 ## [0.21.0] - 2022-02-16
 

--- a/service/controller/orgpermissions/resource/membership/create.go
+++ b/service/controller/orgpermissions/resource/membership/create.go
@@ -62,7 +62,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 func (r *Resource) createOrUpdateClusterRoleBinding(ctx context.Context, orgReadClusterRoleBinding *rbacv1.ClusterRoleBinding) error {
 	existingClusterRoleBinding, err := r.k8sClient.RbacV1().ClusterRoleBindings().Get(ctx, orgReadClusterRoleBinding.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating clusterrolebinding %#q", orgReadClusterRoleBinding.Name))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("creating clusterrolebinding %#q", orgReadClusterRoleBinding.Name))
 
 		_, err := r.k8sClient.RbacV1().ClusterRoleBindings().Create(ctx, orgReadClusterRoleBinding, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
@@ -71,21 +71,18 @@ func (r *Resource) createOrUpdateClusterRoleBinding(ctx context.Context, orgRead
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrolebinding %#q has been created", orgReadClusterRoleBinding.Name))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("clusterrolebinding %#q has been created", orgReadClusterRoleBinding.Name))
 
 	} else if err != nil {
 		return microerror.Mask(err)
 
 	} else if needsUpdate(orgReadClusterRoleBinding, existingClusterRoleBinding) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating clusterrolebinding %#q", orgReadClusterRoleBinding.Name))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("updating clusterrolebinding %#q", orgReadClusterRoleBinding.Name))
 		_, err := r.k8sClient.RbacV1().ClusterRoleBindings().Update(ctx, orgReadClusterRoleBinding, metav1.UpdateOptions{})
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrolebinding %#q has been updated", orgReadClusterRoleBinding.Name))
-
-	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrolebinding %#q already exists", orgReadClusterRoleBinding.Name))
+		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("clusterrolebinding %#q has been updated", orgReadClusterRoleBinding.Name))
 	}
 
 	return nil

--- a/service/controller/orgpermissions/resource/membership/delete.go
+++ b/service/controller/orgpermissions/resource/membership/delete.go
@@ -37,7 +37,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		} else if err != nil {
 			return microerror.Mask(err)
 		} else {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %#q clusterrolebinding", crb))
+			r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("deleting clusterrolebinding %#q", crb))
 
 			err = r.k8sClient.RbacV1().ClusterRoleBindings().Delete(ctx, crb, metav1.DeleteOptions{})
 			if apierrors.IsNotFound(err) {
@@ -46,7 +46,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			if err != nil {
 				return microerror.Mask(err)
 			} else {
-				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrolebinding %#q has been deleted", crb))
+				r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("clusterrolebinding %#q has been deleted", crb))
 			}
 		}
 	}


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation `giantswarm.io/notes` to help explain their purpose and usage.
