### PR TITLE
dynamically bind read/write in cluster namespace roles for read-all and cluster-admin users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Dynamically bind `read-in-cluster-ns` clusterRole if `read-all` clusterRole is bound in an org-namespace
+- Dynamically bind `write-in-cluster-ns` clusterRole if `cluster-admin` clusterRole is bound in an org-namespace 
+
+
 ### Changed
 
 - Renamed role `read-cluster-apps-in-cluster-ns` to `read-in-cluster-ns`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Prevent rbac-controller `fluxauth` and `externalresources` resources from reconciling cluster namespaces
 - Dynamically bind `read-in-cluster-ns` clusterRole if `read-all` clusterRole is bound in an org-namespace
 - Dynamically bind `write-in-cluster-ns` clusterRole if `cluster-admin` clusterRole is bound in an org-namespace 
 

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -68,8 +68,16 @@ func OrganizationReadDefaultCatalogsRoleBindingName(organization string) string 
 	return fmt.Sprintf("default-catalogs-organization-%s-read", organization)
 }
 
+func OrganizationReadClusterNamespaceRoleBindingName(organization string) string {
+	return fmt.Sprintf("cluster-ns-organization-%s-read", organization)
+}
+
 func OrganizationReadReleasesClusterRoleBindingName(organization string) string {
 	return fmt.Sprintf("releases-organization-%s-read", organization)
+}
+
+func OrganizationWriteClusterNamespaceRoleBindingName(organization string) string {
+	return fmt.Sprintf("cluster-ns-organization-%s-write", organization)
 }
 
 func ReadAllCustomerGroupClusterRoleBindingName() string {

--- a/service/controller/rbac/resource/externalresources/create.go
+++ b/service/controller/rbac/resource/externalresources/create.go
@@ -24,6 +24,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 	orgNamespace := ns.Name
 
+	if !pkgkey.IsOrgNamespace(orgNamespace) {
+		return nil
+	}
+
 	// List roleBindings in org-namespace
 	orgRoleBindings, err := r.k8sClient.RbacV1().RoleBindings(orgNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {

--- a/service/controller/rbac/resource/externalresources/create.go
+++ b/service/controller/rbac/resource/externalresources/create.go
@@ -53,15 +53,16 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 // - write-access toresources in the org cluster namespaces
 func (r *Resource) ensureClusterNamespaceAccess(ctx context.Context, orgNamespace string, orgRoleBindings *rbacv1.RoleBindingList) error {
 	var err error
+	organization := pkgkey.OrganizationName(orgNamespace)
 
 	subjects := getUniqueSubjectsWithClusterRoleRef(orgRoleBindings, pkgkey.DefaultReadAllPermissionsName)
-	err = r.ensureRoleBindingToClusterRole(ctx, subjects, pkgkey.ReadClusterNamespaceAppsRole, orgNamespace, pkgkey.ReadClusterNamespaceAppsRoleBinding)
+	err = r.ensureRoleBindingToClusterRole(ctx, subjects, pkgkey.ReadClusterNamespaceAppsRole, orgNamespace, pkgkey.OrganizationReadClusterNamespaceRoleBindingName(organization))
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
 	subjects = getUniqueSubjectsWithClusterRoleRef(orgRoleBindings, pkgkey.ClusterAdminClusterRoleName)
-	err = r.ensureRoleBindingToClusterRole(ctx, subjects, pkgkey.WriteClusterNamespaceAppsRole, orgNamespace, pkgkey.WriteClusterNamespaceAppsRoleBinding)
+	err = r.ensureRoleBindingToClusterRole(ctx, subjects, pkgkey.WriteClusterNamespaceAppsRole, orgNamespace, pkgkey.OrganizationWriteClusterNamespaceRoleBindingName(organization))
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/rbac/resource/externalresources/create.go
+++ b/service/controller/rbac/resource/externalresources/create.go
@@ -15,9 +15,6 @@ import (
 	"github.com/giantswarm/rbac-operator/service/controller/rbac/key"
 )
 
-// Ensures that Subjects with any sort of access in the organization namespace also have read access to
-// - releases (non-namespaced)
-// - app catalogs and app catalog entries in the default namespace
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	var err error
 
@@ -34,6 +31,79 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	} else if len(orgRoleBindings.Items) == 0 {
 		return nil
 	}
+
+	// Ensure RoleBinding for default app catalogs access and ClusterRoleBinding for releases access
+	err = r.ensureAll(ctx, orgNamespace, orgRoleBindings)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Ensure RoleBindings for read/write access to cluster namespace resources
+	err = r.ensureClusterNamespaceAccess(ctx, orgNamespace, orgRoleBindings)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+// Ensures that Subjects with full read access to the org-namespace also have
+// - read-access to resources in the org cluster namespaces
+// Ensures that Subjects with admin access to the org-namespace also have
+// - write-access toresources in the org cluster namespaces
+func (r *Resource) ensureClusterNamespaceAccess(ctx context.Context, orgNamespace string, orgRoleBindings *rbacv1.RoleBindingList) error {
+	var err error
+
+	subjects := getUniqueSubjectsWithClusterRoleRef(orgRoleBindings, pkgkey.DefaultReadAllPermissionsName)
+	err = r.ensureRoleBindingToClusterRole(ctx, subjects, pkgkey.ReadClusterNamespaceAppsRole, orgNamespace, pkgkey.ReadClusterNamespaceAppsRoleBinding)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	subjects = getUniqueSubjectsWithClusterRoleRef(orgRoleBindings, pkgkey.ClusterAdminClusterRoleName)
+	err = r.ensureRoleBindingToClusterRole(ctx, subjects, pkgkey.WriteClusterNamespaceAppsRole, orgNamespace, pkgkey.WriteClusterNamespaceAppsRoleBinding)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) ensureRoleBindingToClusterRole(ctx context.Context, subjects []rbacv1.Subject, clusterRole string, namespace string, name string) error {
+	var err error
+
+	roleBinding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				label.ManagedBy: project.Name(),
+			},
+			Namespace: namespace,
+		},
+		Subjects: subjects,
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     clusterRole,
+		},
+	}
+
+	if err = r.createOrUpdateRoleBinding(ctx, roleBinding.Namespace, roleBinding); err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+// Ensures that Subjects with any sort of access in the organization namespace also have read access to
+// - releases (non-namespaced)
+// - app catalogs and app catalog entries in the default namespace
+func (r *Resource) ensureAll(ctx context.Context, orgNamespace string, orgRoleBindings *rbacv1.RoleBindingList) error {
+	var err error
 
 	// Collect the subjects that need access
 	subjects := getUniqueSubjects(orgRoleBindings)

--- a/service/controller/rbac/resource/externalresources/delete.go
+++ b/service/controller/rbac/resource/externalresources/delete.go
@@ -19,7 +19,12 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	organization := pkgkey.OrganizationName(ns.Name)
+	orgNamespace := ns.Name
+	organization := pkgkey.OrganizationName(orgNamespace)
+
+	if !pkgkey.IsOrgNamespace(orgNamespace) {
+		return nil
+	}
 
 	// Delete RoleBinding for default app catalogs access
 	err = r.deleteRoleBinding(ctx, pkgkey.DefaultNamespaceName, pkgkey.OrganizationReadDefaultCatalogsRoleBindingName(organization))
@@ -33,14 +38,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	// Delete ClusterRoleBinding to read cluster namespaces
-	err = r.deleteClusterRoleBinding(ctx, pkgkey.OrganizationReadClusterNamespaceRoleBindingName(organization))
+	// Delete RoleBinding to read cluster namespaces
+	err = r.deleteRoleBinding(ctx, orgNamespace, pkgkey.OrganizationReadClusterNamespaceRoleBindingName(organization))
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	// Delete ClusterRoleBinding to write in cluster namespaces
-	err = r.deleteClusterRoleBinding(ctx, pkgkey.OrganizationWriteClusterNamespaceRoleBindingName(organization))
+	// Delete RoleBinding to write in cluster namespaces
+	err = r.deleteRoleBinding(ctx, orgNamespace, pkgkey.OrganizationWriteClusterNamespaceRoleBindingName(organization))
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/rbac/resource/externalresources/delete.go
+++ b/service/controller/rbac/resource/externalresources/delete.go
@@ -32,6 +32,18 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
+
+	// Delete ClusterRoleBinding to read cluster namespaces
+	err = r.deleteClusterRoleBinding(ctx, pkgkey.OrganizationReadClusterNamespaceRoleBindingName(organization))
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Delete ClusterRoleBinding to write in cluster namespaces
+	err = r.deleteClusterRoleBinding(ctx, pkgkey.OrganizationWriteClusterNamespaceRoleBindingName(organization))
+	if err != nil {
+		return microerror.Mask(err)
+	}
 	return nil
 }
 

--- a/service/controller/rbac/resource/externalresources/resource.go
+++ b/service/controller/rbac/resource/externalresources/resource.go
@@ -47,6 +47,22 @@ func (r *Resource) Name() string {
 	return Name
 }
 
+func getUniqueSubjectsWithClusterRoleRef(orgRoleBindings *rbacv1.RoleBindingList, clusterRole string) []rbacv1.Subject {
+	readAllSubjects := make(map[string]rbacv1.Subject)
+	for _, roleBinding := range orgRoleBindings.Items {
+		if roleBindingReferencesClusterRole(roleBinding, clusterRole) && roleBindingHasSubject(roleBinding) {
+			for _, subject := range roleBinding.Subjects {
+				readAllSubjects[subject.Kind+subject.Name] = subject
+			}
+		}
+	}
+	var subjects []rbacv1.Subject
+	for _, value := range readAllSubjects {
+		subjects = append(subjects, value)
+	}
+	return subjects
+}
+
 func getUniqueSubjects(orgRoleBindings *rbacv1.RoleBindingList) []rbacv1.Subject {
 	uniqueSubjects := make(map[string]rbacv1.Subject)
 	for _, roleBinding := range orgRoleBindings.Items {
@@ -102,5 +118,12 @@ func roleBindingNeedsUpdate(desiredRoleBinding, existingRoleBinding *rbacv1.Role
 		return true
 	}
 
+	return false
+}
+
+func roleBindingReferencesClusterRole(roleBinding rbacv1.RoleBinding, roleName string) bool {
+	if roleBinding.RoleRef.Name == roleName && roleBinding.RoleRef.Kind == "ClusterRole" {
+		return true
+	}
 	return false
 }

--- a/service/controller/rbac/resource/fluxauth/create.go
+++ b/service/controller/rbac/resource/fluxauth/create.go
@@ -48,6 +48,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	if !pkgkey.IsOrgNamespace(ns.Name) {
+		return nil
+	}
+
 	// create "automation" ServiceAccount in org namespace
 	{
 		serviceAccount := &corev1.ServiceAccount{

--- a/service/controller/rbac/resource/fluxauth/delete.go
+++ b/service/controller/rbac/resource/fluxauth/delete.go
@@ -17,6 +17,9 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	if err != nil {
 		return microerror.Mask(err)
 	}
+	if !pkgkey.IsOrgNamespace(ns.Name) {
+		return nil
+	}
 
 	roleBindings := []string{
 		pkgkey.FluxCRDRoleBindingName,

--- a/service/internal/bootstrap/clusternamespace.go
+++ b/service/internal/bootstrap/clusternamespace.go
@@ -28,7 +28,7 @@ func (b *Bootstrap) createReadClusterNamespaceAppsRole(ctx context.Context) erro
 			Name: key.ReadClusterNamespaceAppsRole,
 			Labels: map[string]string{
 				label.ManagedBy:              project.Name(),
-				label.DisplayInUserInterface: "true",
+				label.DisplayInUserInterface: "false",
 			},
 			Annotations: map[string]string{
 				annotation.Notes: "If referenced within an organization namespace, grants read-only (get, list, watch) permissions to app resources in cluster namespaces belonging to the organization.",
@@ -55,7 +55,7 @@ func (b *Bootstrap) createWriteClusterNamespaceAppsRole(ctx context.Context) err
 			Name: key.WriteClusterNamespaceAppsRole,
 			Labels: map[string]string{
 				label.ManagedBy:              project.Name(),
-				label.DisplayInUserInterface: "true",
+				label.DisplayInUserInterface: "false",
 			},
 			Annotations: map[string]string{
 				annotation.Notes: "If referenced within an organization namespace, grants read and write permissions to app resources in cluster namespaces belonging to the organization.",

--- a/service/internal/bootstrap/clusternamespace.go
+++ b/service/internal/bootstrap/clusternamespace.go
@@ -28,7 +28,7 @@ func (b *Bootstrap) createReadClusterNamespaceAppsRole(ctx context.Context) erro
 			Name: key.ReadClusterNamespaceAppsRole,
 			Labels: map[string]string{
 				label.ManagedBy:              project.Name(),
-				label.DisplayInUserInterface: "false",
+				label.DisplayInUserInterface: "true",
 			},
 			Annotations: map[string]string{
 				annotation.Notes: "If referenced within an organization namespace, grants read-only (get, list, watch) permissions to app resources in cluster namespaces belonging to the organization.",
@@ -55,7 +55,7 @@ func (b *Bootstrap) createWriteClusterNamespaceAppsRole(ctx context.Context) err
 			Name: key.WriteClusterNamespaceAppsRole,
 			Labels: map[string]string{
 				label.ManagedBy:              project.Name(),
-				label.DisplayInUserInterface: "false",
+				label.DisplayInUserInterface: "true",
 			},
 			Annotations: map[string]string{
 				annotation.Notes: "If referenced within an organization namespace, grants read and write permissions to app resources in cluster namespaces belonging to the organization.",


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21089

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation `giantswarm.io/notes` to help explain their purpose and usage.
