### PR TITLE
replace orgpermissions with externalresources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `externalresources` resource that binds `organization-$org-read` role for any subject with org-namespace access.
+- Deprecate `orgpermissions` controller as it is replaced by the above.
+
 ## [0.23.0] - 2022-03-02
 
 ### Added

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -76,6 +76,10 @@ func OrganizationReadReleasesClusterRoleBindingName(organization string) string 
 	return fmt.Sprintf("releases-organization-%s-read", organization)
 }
 
+func OrganizationReadOrganizationClusterRoleBindingName(organization string) string {
+	return fmt.Sprintf("organization-organization-%s-read", organization)
+}
+
 func OrganizationWriteClusterNamespaceRoleBindingName(organization string) string {
 	return fmt.Sprintf("cluster-ns-organization-%s-write", organization)
 }

--- a/service/controller/orgpermissions/resource/membership/create.go
+++ b/service/controller/orgpermissions/resource/membership/create.go
@@ -12,6 +12,5 @@ import (
 // The deletion logic remains to help cleaning up
 //
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	// return r.EnsureDeleted(ctx, obj)
-	return nil
+	return r.EnsureDeleted(ctx, obj)
 }

--- a/service/controller/orgpermissions/resource/membership/create.go
+++ b/service/controller/orgpermissions/resource/membership/create.go
@@ -2,99 +2,16 @@ package membership
 
 import (
 	"context"
-	"fmt"
-	"reflect"
-
-	"github.com/giantswarm/microerror"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	pkgkey "github.com/giantswarm/rbac-operator/pkg/key"
-	"github.com/giantswarm/rbac-operator/pkg/label"
-	"github.com/giantswarm/rbac-operator/pkg/project"
-	"github.com/giantswarm/rbac-operator/service/controller/orgpermissions/key"
 )
 
 // Ensures that a ClusterRoleBinding '<rolebinding-name>-organization-<organization>-read'
 // exists for a certain RoleBinding, with the same subjects.
+//
+// DEPRECATED
+// This resource is replaced by the rbac/externalresources resource.
+// The deletion logic remains to help cleaning up
+//
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	var err error
-
-	roleBinding, err := key.ToRoleBinding(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	if !pkgkey.IsOrgNamespace(roleBinding.Namespace) || !isTargetRoleBinding(roleBinding) {
-		return nil
-	}
-
-	orgName := pkgkey.OrganizationName(roleBinding.Namespace)
-	orgReadClusterRoleBindingName := pkgkey.OrganizationReadClusterRoleBindingName(roleBinding.Name, orgName)
-	orgReadClusterRoleName := pkgkey.OrganizationReadClusterRoleName(roleBinding.Namespace)
-
-	orgReadClusterRoleBinding := &rbacv1.ClusterRoleBinding{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ClusterRoleBinding",
-			APIVersion: "rbac.authorization.k8s.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: orgReadClusterRoleBindingName,
-			Labels: map[string]string{
-				label.ManagedBy: project.Name(),
-			},
-		},
-		Subjects: roleBinding.Subjects,
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     orgReadClusterRoleName,
-		},
-	}
-	err = r.createOrUpdateClusterRoleBinding(ctx, orgReadClusterRoleBinding)
-	if err != nil {
-		return microerror.Mask(err)
-	}
+	// return r.EnsureDeleted(ctx, obj)
 	return nil
-}
-
-func (r *Resource) createOrUpdateClusterRoleBinding(ctx context.Context, orgReadClusterRoleBinding *rbacv1.ClusterRoleBinding) error {
-	existingClusterRoleBinding, err := r.k8sClient.RbacV1().ClusterRoleBindings().Get(ctx, orgReadClusterRoleBinding.Name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("creating clusterrolebinding %#q", orgReadClusterRoleBinding.Name))
-
-		_, err := r.k8sClient.RbacV1().ClusterRoleBindings().Create(ctx, orgReadClusterRoleBinding, metav1.CreateOptions{})
-		if apierrors.IsAlreadyExists(err) {
-			// do nothing
-		} else if err != nil {
-			return microerror.Mask(err)
-		}
-
-		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("clusterrolebinding %#q has been created", orgReadClusterRoleBinding.Name))
-
-	} else if err != nil {
-		return microerror.Mask(err)
-
-	} else if needsUpdate(orgReadClusterRoleBinding, existingClusterRoleBinding) {
-		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("updating clusterrolebinding %#q", orgReadClusterRoleBinding.Name))
-		_, err := r.k8sClient.RbacV1().ClusterRoleBindings().Update(ctx, orgReadClusterRoleBinding, metav1.UpdateOptions{})
-		if err != nil {
-			return microerror.Mask(err)
-		}
-		r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("clusterrolebinding %#q has been updated", orgReadClusterRoleBinding.Name))
-	}
-
-	return nil
-}
-
-func needsUpdate(desiredClusterRoleBinding, existingClusterRoleBinding *rbacv1.ClusterRoleBinding) bool {
-	if len(existingClusterRoleBinding.Subjects) < 1 {
-		return true
-	}
-	if !reflect.DeepEqual(desiredClusterRoleBinding.Subjects, existingClusterRoleBinding.Subjects) {
-		return true
-	}
-
-	return false
 }

--- a/service/controller/rbac/resource/externalresources/delete.go
+++ b/service/controller/rbac/resource/externalresources/delete.go
@@ -38,6 +38,12 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	// Delete ClusterRoleBinding for access to organization cr by name
+	err = r.deleteClusterRoleBinding(ctx, pkgkey.OrganizationReadOrganizationClusterRoleBindingName(organization))
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	// Delete RoleBinding to read cluster namespaces
 	err = r.deleteRoleBinding(ctx, orgNamespace, pkgkey.OrganizationReadClusterNamespaceRoleBindingName(organization))
 	if err != nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/21477

The `orgpermissions` controller reconciles `rolebindings` in the org namespace and creates one `clusterrolebinding` for each of them that gives the subjects read-access to the organization cr by name.
This is messy as it creates a lot of `clusterrolebindings` and also does not work for rolebindings wmanaged by the operator itself.

This PR replaces the old controller by creating just one rolebinding for all the subjects. Since we already have similar logic for access to releases there I have added this to the `externalresources`.

Also this deprecates the `orgpermissions` controller. For now the creation logic is removed and I want to see if we can use it to clean up the existing clusterrolebindings since they will be hard to manually clean up.
Afterwards we can release a patch that removes the entire controller.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation `giantswarm.io/notes` to help explain their purpose and usage.
