### PR TITLE
Removing `ClusterRoleBinding` for `default:automation` SA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Deleted
+
+- Delete `write-flux-resources-customer-sa` ClusterRoleBinding.
+
 ## [0.27.0] - 2022-04-28
 
 ## Added

--- a/service/internal/bootstrap/bootstrap.go
+++ b/service/internal/bootstrap/bootstrap.go
@@ -112,11 +112,6 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		return microerror.Mask(err)
 	}
 
-	err = b.createWriteFluxResourcesClusterRoleBindingToAutomationSA(ctx)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
 	err = b.createWriteClustersClusterRole(ctx)
 	if err != nil {
 		return microerror.Mask(err)


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/22096

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation `giantswarm.io/notes` to help explain their purpose and usage.
