### PR TITLE
Added support for multiple admin groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 TODO
 /rbac-operator*
 !vendor/**
+.idea

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -10,4 +10,6 @@ type Service struct {
 
 	WriteAllCustomerGroup   string
 	WriteAllGiantswarmGroup string
+
+	AccessGroups string
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.12.2
 	github.com/spf13/viper v1.12.0
 	k8s.io/api v0.24.3
+	k8s.io/apiextensions-apiserver v0.24.3
 	k8s.io/apimachinery v0.24.3
 	k8s.io/client-go v0.24.3
 	sigs.k8s.io/controller-runtime v0.12.3
@@ -91,7 +92,6 @@ require (
 	gopkg.in/resty.v1 v1.12.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.24.3 // indirect
 	k8s.io/component-base v0.24.3 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220627174259-011e075b9cb8 // indirect

--- a/helm/rbac-operator/templates/configmap.yaml
+++ b/helm/rbac-operator/templates/configmap.yaml
@@ -23,6 +23,20 @@ data:
           keyFile: ''
       accessGroups:
         writeAllCustomerGroups:
+        {{- if .Values.oidc.customer.write_all_group }}
         - name: {{ .Values.oidc.customer.write_all_group }}
+        {{- end }}
+        {{- if .Values.oidc.customer.write_all_groups }}
+        {{- range .Values.oidc.customer.write_all_groups }}
+        - name: {{ . }}
+        {{- end }}
+        {{- end }}
         writeAllGiantswarmGroups:
+        {{- if .Values.oidc.giantswarm.write_all_group }}
         - name: {{ .Values.oidc.giantswarm.write_all_group }}
+        {{- end }}
+        {{- if .Values.oidc.giantswarm.write_all_groups }}
+        {{- range .Values.oidc.giantswarm.write_all_groups }}
+        - name: {{ . }}
+        {{- end }}
+        {{- end }}

--- a/helm/rbac-operator/templates/configmap.yaml
+++ b/helm/rbac-operator/templates/configmap.yaml
@@ -21,5 +21,8 @@ data:
           caFile: ''
           crtFile: ''
           keyFile: ''
-      writeAllCustomerGroup: {{ .Values.oidc.customer.write_all_group }}
-      writeAllGiantswarmGroup: {{ .Values.oidc.giantswarm.write_all_group}}
+      accessGroups:
+        writeAllCustomerGroups:
+        - name: {{ .Values.oidc.customer.write_all_group }}
+        writeAllGiantswarmGroups:
+        - name: {{ .Values.oidc.giantswarm.write_all_group }}

--- a/main.go
+++ b/main.go
@@ -109,6 +109,7 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CAFile, "", "Certificate authority file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CrtFile, "", "Certificate file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.KeyFile, "", "Key file path to use to authenticate with Kubernetes.")
+	daemonCommand.PersistentFlags().String(f.Service.AccessGroups, "", "Groups to be granted access to resources in the cluster")
 
 	err = newCommand.CobraCommand().Execute()
 	if err != nil {

--- a/service/controller/clusternamespace/resource/clusternamespaceresources/create.go
+++ b/service/controller/clusternamespace/resource/clusternamespaceresources/create.go
@@ -19,9 +19,9 @@ import (
 )
 
 // EnsureCreated Ensures that
-// - Roles for read/write access to org cluster resources are ensured in each cluster namespace
-// - For each RoleBinding in an org-namespace that references the read/write org cluster resource clusterRole,
-//   RoleBindings are created in the organizations cluster namespaces which reference above Role
+//   - Roles for read/write access to org cluster resources are ensured in each cluster namespace
+//   - For each RoleBinding in an org-namespace that references the read/write org cluster resource clusterRole,
+//     RoleBindings are created in the organizations cluster namespaces which reference above Role
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	var err error
 

--- a/service/controller/rbac/rbac.go
+++ b/service/controller/rbac/rbac.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/v7/pkg/controller"
 	"github.com/giantswarm/operatorkit/v7/pkg/resource"
+	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -16,7 +17,7 @@ type RBACConfig struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
 
-	WriteAllCustomerGroup string
+	WriteAllCustomerGroups []accessgroup.AccessGroup
 }
 
 type RBAC struct {

--- a/service/controller/rbac/rbac.go
+++ b/service/controller/rbac/rbac.go
@@ -6,9 +6,10 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/v7/pkg/controller"
 	"github.com/giantswarm/operatorkit/v7/pkg/resource"
-	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 
 	"github.com/giantswarm/rbac-operator/pkg/project"
 )

--- a/service/controller/rbac/rbac_resources.go
+++ b/service/controller/rbac/rbac_resources.go
@@ -7,6 +7,7 @@ import (
 	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 	"github.com/giantswarm/operatorkit/v7/pkg/resource/wrapper/metricsresource"
 	"github.com/giantswarm/operatorkit/v7/pkg/resource/wrapper/retryresource"
+	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 
 	"github.com/giantswarm/rbac-operator/service/controller/rbac/resource/externalresources"
 	"github.com/giantswarm/rbac-operator/service/controller/rbac/resource/fluxauth"
@@ -17,7 +18,7 @@ type rbacResourcesConfig struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
 
-	WriteAllCustomerGroup string
+	WriteAllCustomerGroups []accessgroup.AccessGroup
 }
 
 func newRBACResources(config rbacResourcesConfig) ([]resource.Interface, error) {
@@ -55,7 +56,7 @@ func newRBACResources(config rbacResourcesConfig) ([]resource.Interface, error) 
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 
-			WriteAllCustomerGroup: config.WriteAllCustomerGroup,
+			WriteAllCustomerGroups: config.WriteAllCustomerGroups,
 		}
 
 		namespaceAuthResource, err = namespaceauth.New(c)

--- a/service/controller/rbac/rbac_resources.go
+++ b/service/controller/rbac/rbac_resources.go
@@ -7,6 +7,7 @@ import (
 	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 	"github.com/giantswarm/operatorkit/v7/pkg/resource/wrapper/metricsresource"
 	"github.com/giantswarm/operatorkit/v7/pkg/resource/wrapper/retryresource"
+
 	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 
 	"github.com/giantswarm/rbac-operator/service/controller/rbac/resource/externalresources"

--- a/service/controller/rbac/resource/namespaceauth/create.go
+++ b/service/controller/rbac/resource/namespaceauth/create.go
@@ -3,13 +3,14 @@ package namespaceauth
 import (
 	"context"
 	"fmt"
-	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 
 	k8smetadata "github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/microerror"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 
 	pkgkey "github.com/giantswarm/rbac-operator/pkg/key"
 	"github.com/giantswarm/rbac-operator/pkg/project"

--- a/service/controller/rbac/resource/namespaceauth/resource.go
+++ b/service/controller/rbac/resource/namespaceauth/resource.go
@@ -4,6 +4,7 @@ import (
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+
 	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 
 	"k8s.io/client-go/kubernetes"

--- a/service/controller/rbac/resource/namespaceauth/resource.go
+++ b/service/controller/rbac/resource/namespaceauth/resource.go
@@ -4,6 +4,7 @@ import (
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 
 	"k8s.io/client-go/kubernetes"
 )
@@ -16,14 +17,14 @@ type Config struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
 
-	WriteAllCustomerGroup string
+	WriteAllCustomerGroups []accessgroup.AccessGroup
 }
 
 type Resource struct {
 	k8sClient kubernetes.Interface
 	logger    micrologger.Logger
 
-	writeAllCustomerGroup string
+	writeAllCustomerGroups []accessgroup.AccessGroup
 }
 
 func New(config Config) (*Resource, error) {
@@ -38,7 +39,7 @@ func New(config Config) (*Resource, error) {
 		k8sClient: config.K8sClient.K8sClient(),
 		logger:    config.Logger,
 
-		writeAllCustomerGroup: config.WriteAllCustomerGroup,
+		writeAllCustomerGroups: config.WriteAllCustomerGroups,
 	}
 
 	return r, nil

--- a/service/internal/accessgroup/accessgroup.go
+++ b/service/internal/accessgroup/accessgroup.go
@@ -1,0 +1,34 @@
+package accessgroup
+
+type AccessGroup struct {
+	Name string
+}
+
+type AccessGroups struct {
+	WriteAllCustomerGroups   []AccessGroup
+	WriteAllGiantswarmGroups []AccessGroup
+}
+
+func (a *AccessGroups) AddLegacyCustomerAdminGroup(legacyGroupName string) {
+	a.WriteAllCustomerGroups = addLegacyGroupIfMissing(a.WriteAllCustomerGroups, legacyGroupName)
+}
+
+func (a *AccessGroups) AddLegacyGiantswarmAdminGroup(legacyGroupName string) {
+	a.WriteAllGiantswarmGroups = addLegacyGroupIfMissing(a.WriteAllGiantswarmGroups, legacyGroupName)
+}
+
+func (a *AccessGroups) Validate() bool {
+	return len(a.WriteAllCustomerGroups) > 0 && len(a.WriteAllGiantswarmGroups) > 0
+}
+
+func addLegacyGroupIfMissing(groups []AccessGroup, legacyGroupName string) []AccessGroup {
+	if legacyGroupName == "" {
+		return groups
+	}
+	for _, group := range groups {
+		if group.Name == legacyGroupName {
+			return groups
+		}
+	}
+	return append(groups, AccessGroup{Name: legacyGroupName})
+}

--- a/service/internal/accessgroup/accessgroup_test.go
+++ b/service/internal/accessgroup/accessgroup_test.go
@@ -1,0 +1,20 @@
+package accessgroup
+
+import "testing"
+
+func Test_LegacyGroupsAreApplied(t *testing.T) {
+	accessGroups := []AccessGroup{
+		{Name: "group1"},
+		{Name: "group2"},
+	}
+
+	accessGroups = addLegacyGroupIfMissing(accessGroups, "legacy:group1")
+	if len(accessGroups) != 3 {
+		t.Fatalf("Incorrect length of access groups - expected: 3, actual: %d", len(accessGroups))
+	}
+
+	accessGroups = addLegacyGroupIfMissing(accessGroups, "group1")
+	if len(accessGroups) != 3 {
+		t.Fatalf("Incorrect length of access groups - expected: 3, actual: %d", len(accessGroups))
+	}
+}

--- a/service/internal/bootstrap/bootstrap.go
+++ b/service/internal/bootstrap/bootstrap.go
@@ -3,6 +3,8 @@ package bootstrap
 import (
 	"context"
 
+	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
+
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -14,8 +16,8 @@ type Config struct {
 	Logger    micrologger.Logger
 
 	// internal
-	CustomerAdminGroup string
-	GSAdminGroup       string
+	CustomerAdminGroups []accessgroup.AccessGroup
+	GSAdminGroups       []accessgroup.AccessGroup
 }
 
 type Bootstrap struct {
@@ -23,8 +25,8 @@ type Bootstrap struct {
 	logger    micrologger.Logger
 
 	// internal
-	customerAdminGroup string
-	gsAdminGroup       string
+	customerAdminGroups []accessgroup.AccessGroup
+	gsAdminGroups       []accessgroup.AccessGroup
 }
 
 func (b Bootstrap) K8sClient() kubernetes.Interface {
@@ -42,7 +44,7 @@ func New(config Config) (*Bootstrap, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
-	if config.GSAdminGroup == "" {
+	if len(config.GSAdminGroups) == 0 {
 		return nil, microerror.Maskf(invalidConfigError, "%T.GSAdminGroup must not be empty", config)
 	}
 
@@ -50,8 +52,8 @@ func New(config Config) (*Bootstrap, error) {
 		k8sClient: config.K8sClient.K8sClient(),
 		logger:    config.Logger,
 
-		customerAdminGroup: config.CustomerAdminGroup,
-		gsAdminGroup:       config.GSAdminGroup,
+		customerAdminGroups: config.CustomerAdminGroups,
+		gsAdminGroups:       config.GSAdminGroups,
 	}
 
 	return r, nil
@@ -165,7 +167,7 @@ func (b *Bootstrap) Run(ctx context.Context) error {
 		return microerror.Mask(err)
 	}
 
-	if b.customerAdminGroup != "" {
+	if len(b.customerAdminGroups) > 0 {
 		err = b.createReadAllClusterRoleBindingToCustomerGroup(ctx)
 		if err != nil {
 			return microerror.Mask(err)

--- a/service/internal/bootstrap/bootstrap.go
+++ b/service/internal/bootstrap/bootstrap.go
@@ -44,8 +44,8 @@ func New(config Config) (*Bootstrap, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
-	if len(config.GSAdminGroups) == 0 {
-		return nil, microerror.Maskf(invalidConfigError, "%T.GSAdminGroup must not be empty", config)
+	if !accessgroup.ValidateGroups(config.GSAdminGroups) {
+		return nil, microerror.Maskf(invalidConfigError, "%T.GSAdminGroups must not be empty", config)
 	}
 
 	r := &Bootstrap{

--- a/service/internal/bootstrap/bootstrap_test.go
+++ b/service/internal/bootstrap/bootstrap_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/giantswarm/k8sclient/v7/pkg/k8scrdclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/giantswarm/rbac-operator/pkg/key"
-	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -20,6 +18,9 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/giantswarm/rbac-operator/pkg/key"
+	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 
 	fakek8s "k8s.io/client-go/kubernetes/fake"
 )

--- a/service/internal/bootstrap/bootstrap_test.go
+++ b/service/internal/bootstrap/bootstrap_test.go
@@ -1,0 +1,281 @@
+package bootstrap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
+	"github.com/giantswarm/k8sclient/v7/pkg/k8scrdclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/rbac-operator/pkg/key"
+	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Bootstrap(t *testing.T) {
+
+	testCases := []struct {
+		Name                        string
+		InitialObjects              []interface{}
+		WriteAllCustomerGroups      []accessgroup.AccessGroup
+		WriteAllGiantswarmGroups    []accessgroup.AccessGroup
+		ExpectedRoleBindings        []rbacv1.RoleBinding
+		ExpectedClusterRoleBindings []rbacv1.ClusterRoleBinding
+		ExpectedError               error
+	}{
+		{
+			Name:                     "case 0: Add new bindings with multiple subjects",
+			WriteAllCustomerGroups:   []accessgroup.AccessGroup{{Name: "customers1"}, {Name: "customers2"}},
+			WriteAllGiantswarmGroups: []accessgroup.AccessGroup{{Name: "giantswarm1"}, {Name: "giantswarm2"}},
+			ExpectedRoleBindings: []rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: key.WriteAllCustomerGroupRoleBindingName()},
+					Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "customers1"}, {Kind: "Group", Name: "customers2"}},
+				},
+			},
+			ExpectedClusterRoleBindings: []rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: key.WriteOrganizationsCustomerGroupClusterRoleBindingName()},
+					Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "customers1"}, {Kind: "Group", Name: "customers2"}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: key.ReadAllCustomerGroupClusterRoleBindingName()},
+					Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "customers1"}, {Kind: "Group", Name: "customers2"}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: key.WriteAllGSGroupClusterRoleBindingName()},
+					Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "giantswarm1"}, {Kind: "Group", Name: "giantswarm2"}},
+				},
+			},
+		},
+		{
+			Name: "case 1: Add multiple subjects to existing bindings",
+			InitialObjects: []interface{}{
+				rbacv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: key.WriteAllCustomerGroupRoleBindingName(), Namespace: key.DefaultNamespaceName},
+					Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "customers"}},
+				},
+				rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: key.WriteOrganizationsCustomerGroupClusterRoleBindingName()},
+					Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "customers"}},
+				},
+				rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: key.ReadAllCustomerGroupClusterRoleBindingName()},
+					Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "customers"}},
+				},
+				rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: key.WriteAllGSGroupClusterRoleBindingName()},
+					Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "giantswarm"}},
+				},
+			},
+			WriteAllCustomerGroups:   []accessgroup.AccessGroup{{Name: "customers1"}, {Name: "customers2"}},
+			WriteAllGiantswarmGroups: []accessgroup.AccessGroup{{Name: "giantswarm1"}, {Name: "giantswarm2"}},
+			ExpectedRoleBindings: []rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: key.WriteAllCustomerGroupRoleBindingName()},
+					Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "customers1"}, {Kind: "Group", Name: "customers2"}},
+				},
+			},
+			ExpectedClusterRoleBindings: []rbacv1.ClusterRoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: key.WriteOrganizationsCustomerGroupClusterRoleBindingName()},
+					Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "customers1"}, {Kind: "Group", Name: "customers2"}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: key.ReadAllCustomerGroupClusterRoleBindingName()},
+					Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "customers1"}, {Kind: "Group", Name: "customers2"}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: key.WriteAllGSGroupClusterRoleBindingName()},
+					Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "giantswarm1"}, {Kind: "Group", Name: "giantswarm2"}},
+				},
+			},
+		},
+		{
+			Name:          "case 2: Fail in attempt to create/update bindings with empty subjects",
+			ExpectedError: invalidConfigError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx := context.TODO()
+
+			loggerConfig := micrologger.Config{}
+			logger, err := micrologger.New(loggerConfig)
+
+			if err != nil {
+				t.Fatalf("Failed to init logger: %s", err)
+			}
+
+			k8sClient, err := FakeK8sClient()
+			if err != nil {
+				t.Fatalf("Failed to init k8s client: %s", err)
+			}
+
+			config := Config{
+				Logger:              logger,
+				K8sClient:           k8sClient,
+				CustomerAdminGroups: tc.WriteAllCustomerGroups,
+				GSAdminGroups:       tc.WriteAllGiantswarmGroups,
+			}
+
+			if len(tc.InitialObjects) > 0 {
+				for _, initialObject := range tc.InitialObjects {
+					if clusterRoleBinding, ok := initialObject.(rbacv1.ClusterRoleBinding); ok {
+						_, err = k8sClient.K8sClient().RbacV1().ClusterRoleBindings().Create(ctx, &clusterRoleBinding, metav1.CreateOptions{})
+					} else if roleBinding, ok := initialObject.(rbacv1.RoleBinding); ok {
+						_, err = k8sClient.K8sClient().RbacV1().RoleBindings(roleBinding.Namespace).Create(ctx, &roleBinding, metav1.CreateOptions{})
+					}
+					if err != nil {
+						t.Fatalf("Failed to create initial object %v", initialObject)
+					}
+				}
+			}
+
+			bootstrap, err := New(config)
+
+			if err == nil {
+				err = bootstrap.Run(ctx)
+			}
+
+			if tc.ExpectedError != nil && err == nil {
+				t.Fatalf("Did not receive an expected error: %s", tc.ExpectedError)
+			} else if err != nil && err != tc.ExpectedError && microerror.Cause(err) != tc.ExpectedError {
+				t.Fatalf("Received an unexpected error: %s", err)
+			}
+
+			clusterRoleBindingList, err := k8sClient.K8sClient().RbacV1().ClusterRoleBindings().List(ctx, metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("Failed to get cluster role bindings: %s", err)
+			}
+			clusterRoleBindingsShouldContain(t, tc.ExpectedClusterRoleBindings, clusterRoleBindingList.Items)
+
+			roleBindingList, err := k8sClient.K8sClient().RbacV1().RoleBindings(key.DefaultNamespaceName).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("Failed to get role bindings: %s", err)
+			}
+			roleBindingsShouldContain(t, tc.ExpectedRoleBindings, roleBindingList.Items)
+		})
+	}
+}
+
+func clusterRoleBindingsShouldContain(t *testing.T, expected []rbacv1.ClusterRoleBinding, actual []rbacv1.ClusterRoleBinding) {
+	for _, expectedItem := range expected {
+		hasItem := false
+		for _, actualItem := range actual {
+			if expectedItem.ObjectMeta.Name == actualItem.ObjectMeta.Name {
+				hasItem = true
+				subjectsShouldEqual(t, actualItem.Kind, actualItem.Name, expectedItem.Subjects, actualItem.Subjects)
+				break
+			}
+		}
+		if !hasItem {
+			t.Fatalf("Missing cluster role binding %v", expectedItem)
+		}
+	}
+}
+
+func roleBindingsShouldContain(t *testing.T, expected []rbacv1.RoleBinding, actual []rbacv1.RoleBinding) {
+	for _, expectedItem := range expected {
+		hasItem := false
+		for _, actualItem := range actual {
+			if expectedItem.ObjectMeta.Name == actualItem.ObjectMeta.Name {
+				hasItem = true
+				subjectsShouldEqual(t, actualItem.Kind, actualItem.Name, expectedItem.Subjects, actualItem.Subjects)
+				break
+			}
+		}
+		if !hasItem {
+			t.Fatalf("Missing role binding %v", expectedItem)
+		}
+	}
+}
+
+func subjectsShouldEqual(t *testing.T, kind string, name string, expected []rbacv1.Subject, actual []rbacv1.Subject) {
+	if len(expected) != len(actual) {
+		t.Fatalf("Subjects don't equal. Expected length %d, received %d", len(expected), len(actual))
+	}
+	for _, expectedSubject := range expected {
+		hasSubject := false
+		for _, actualSubject := range actual {
+			if expectedSubject.Kind == actualSubject.Kind && expectedSubject.Name == actualSubject.Name {
+				hasSubject = true
+				break
+			}
+		}
+		if !hasSubject {
+			t.Fatalf("Missing subject %v in %s %s", expectedSubject, kind, name)
+		}
+	}
+}
+
+type fakeK8sClient struct {
+	ctrlClient client.Client
+	k8sClient  kubernetes.Interface
+	scheme     *runtime.Scheme
+}
+
+func FakeK8sClient() (k8sclient.Interface, error) {
+	var err error
+	var k8sClient k8sclient.Interface
+	{
+		scheme := runtime.NewScheme()
+		err = v1.AddToScheme(scheme)
+		if err != nil {
+			return nil, err
+		}
+
+		k8sClient = &fakeK8sClient{
+			ctrlClient: fake.NewClientBuilder().WithObjects().Build(),
+			k8sClient:  fakek8s.NewSimpleClientset(),
+			scheme:     scheme,
+		}
+	}
+
+	return k8sClient, nil
+}
+
+func (f *fakeK8sClient) CRDClient() k8scrdclient.Interface {
+	return nil
+}
+
+func (f *fakeK8sClient) CtrlClient() client.Client {
+	return f.ctrlClient
+}
+
+func (f *fakeK8sClient) DynClient() dynamic.Interface {
+	return nil
+}
+
+func (f *fakeK8sClient) ExtClient() clientset.Interface {
+	return nil
+}
+
+func (f *fakeK8sClient) K8sClient() kubernetes.Interface {
+	return f.k8sClient
+}
+
+func (f *fakeK8sClient) RESTClient() rest.Interface {
+	return nil
+}
+
+func (f *fakeK8sClient) RESTConfig() *rest.Config {
+	return nil
+}
+
+func (f *fakeK8sClient) Scheme() *runtime.Scheme {
+	return f.scheme
+}

--- a/service/internal/bootstrap/resources.go
+++ b/service/internal/bootstrap/resources.go
@@ -6,7 +6,6 @@ package bootstrap
 import (
 	"context"
 	"fmt"
-	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/k8smetadata/pkg/label"
@@ -16,6 +15,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 
 	"github.com/giantswarm/rbac-operator/pkg/key"
 	"github.com/giantswarm/rbac-operator/pkg/project"

--- a/service/internal/bootstrap/resources.go
+++ b/service/internal/bootstrap/resources.go
@@ -10,7 +10,6 @@ import (
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -20,6 +19,8 @@ import (
 	"github.com/giantswarm/rbac-operator/pkg/key"
 	"github.com/giantswarm/rbac-operator/pkg/project"
 	"github.com/giantswarm/rbac-operator/pkg/rbac"
+
+	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 )
 
 // Ensures the 'automation' service account in the default namespace.

--- a/service/service.go
+++ b/service/service.go
@@ -119,8 +119,8 @@ func New(config Config) (*Service, error) {
 		legacyGiantswarmAdminGroup := config.Viper.GetString(config.Flag.Service.WriteAllGiantswarmGroup)
 		accessGroups.AddLegacyGiantswarmAdminGroup(legacyGiantswarmAdminGroup)
 
-		if !accessGroups.Validate() {
-			return nil, microerror.Maskf(invalidConfigError, "Customer and Giantswarm access groups must not be empty")
+		if !accessGroups.HasValidWriteAllGiantswarmAdminGroups() {
+			return nil, microerror.Maskf(invalidConfigError, "Giantswarm Write All Admin groups must not be empty")
 		}
 	}
 
@@ -161,7 +161,7 @@ func New(config Config) (*Service, error) {
 			K8sClient: k8sClient,
 			Logger:    config.Logger,
 
-			WriteAllCustomerGroup: config.Viper.GetString(config.Flag.Service.WriteAllCustomerGroup),
+			WriteAllCustomerGroups: accessGroups.WriteAllCustomerGroups,
 		}
 
 		rbacController, err = rbac.NewRBAC(c)

--- a/service/service.go
+++ b/service/service.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"sync"
 
+	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
+
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8srestconfig"
 	"github.com/giantswarm/microendpoint/service/version"
@@ -51,7 +53,9 @@ func New(config Config) (*Service, error) {
 	if config.Viper == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Viper must not be empty")
 	}
-	if config.Flag.Service.Kubernetes.KubeConfig == "" {
+
+	kubeConfig := config.Viper.GetString(config.Flag.Service.Kubernetes.KubeConfig)
+	if kubeConfig == "" {
 		serviceAddress = config.Viper.GetString(config.Flag.Service.Kubernetes.Address)
 	} else {
 		serviceAddress = ""
@@ -71,7 +75,7 @@ func New(config Config) (*Service, error) {
 
 			Address:    serviceAddress,
 			InCluster:  config.Viper.GetBool(config.Flag.Service.Kubernetes.InCluster),
-			KubeConfig: config.Viper.GetString(config.Flag.Service.Kubernetes.KubeConfig),
+			KubeConfig: kubeConfig,
 			TLS: k8srestconfig.ConfigTLS{
 				CAFile:  config.Viper.GetString(config.Flag.Service.Kubernetes.TLS.CAFile),
 				CrtFile: config.Viper.GetString(config.Flag.Service.Kubernetes.TLS.CrtFile),
@@ -101,14 +105,33 @@ func New(config Config) (*Service, error) {
 		}
 	}
 
+	var accessGroups accessgroup.AccessGroups
+	{
+		err = config.Viper.UnmarshalKey(config.Flag.Service.AccessGroups, &accessGroups)
+		if err != nil {
+			// TODO: Log error
+			accessGroups = accessgroup.AccessGroups{}
+		}
+
+		legacyCustomerAdminGroup := config.Viper.GetString(config.Flag.Service.WriteAllCustomerGroup)
+		accessGroups.AddLegacyCustomerAdminGroup(legacyCustomerAdminGroup)
+
+		legacyGiantswarmAdminGroup := config.Viper.GetString(config.Flag.Service.WriteAllGiantswarmGroup)
+		accessGroups.AddLegacyGiantswarmAdminGroup(legacyGiantswarmAdminGroup)
+
+		if !accessGroups.Validate() {
+			return nil, microerror.Maskf(invalidConfigError, "Customer and Giantswarm access groups must not be empty")
+		}
+	}
+
 	var bootstrapRunner *bootstrap.Bootstrap
 	{
 		c := bootstrap.Config{
 			Logger:    config.Logger,
 			K8sClient: k8sClient,
 
-			CustomerAdminGroup: config.Viper.GetString(config.Flag.Service.WriteAllCustomerGroup),
-			GSAdminGroup:       config.Viper.GetString(config.Flag.Service.WriteAllGiantswarmGroup),
+			CustomerAdminGroups: accessGroups.WriteAllCustomerGroups,
+			GSAdminGroups:       accessGroups.WriteAllGiantswarmGroups,
 		}
 
 		bootstrapRunner, err = bootstrap.New(c)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/giantswarm/rbac-operator/flag"
 	"github.com/spf13/viper"
+
+	"github.com/giantswarm/rbac-operator/flag"
 )
 
 func Test_Service(t *testing.T) {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/rbac-operator/flag"
+	"github.com/spf13/viper"
+)
+
+func Test_Service(t *testing.T) {
+	testCases := []struct {
+		Name                          string
+		WriteAllCustomerGroups        []map[string]string
+		WriteAllGiantswarmGroups      []map[string]string
+		LegacyWriteAllCustomerGroup   string
+		LegacyWriteAllGiantswarmGroup string
+		ExpectedError                 error
+	}{
+		{
+			Name:                     "case 0: Instantiate Service with defined access group lists",
+			WriteAllCustomerGroups:   []map[string]string{{"name": "customer:acme:Employees"}},
+			WriteAllGiantswarmGroups: []map[string]string{{"name": "giantswarm:giantswarm:giantswarm-admins"}},
+		},
+		{
+			Name:                          "case 1: Instantiate Service with legacy access groups",
+			LegacyWriteAllCustomerGroup:   "customer:acme:Employees",
+			LegacyWriteAllGiantswarmGroup: "giantswarm:giantswarm:giantswarm-admins",
+		},
+		{
+			Name:          "case 2: Fail to instantiate service without any access groups defined",
+			ExpectedError: invalidConfigError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			server := mockKubernetesApiServer()
+			defer server.Close()
+
+			loggerConfig := micrologger.Config{}
+			logger, err := micrologger.New(loggerConfig)
+
+			if err != nil {
+				t.Fatalf("Failed to init logger: %s", err)
+			}
+
+			v := viper.New()
+			v.Set("service.kubernetes.address", server.URL)
+
+			if len(tc.WriteAllCustomerGroups) > 0 {
+				v.Set("service.accessGroups.writeAllCustomerGroups", tc.WriteAllCustomerGroups)
+			}
+			if len(tc.WriteAllGiantswarmGroups) > 0 {
+				v.Set("service.accessGroups.writeAllGiantswarmGroups", tc.WriteAllGiantswarmGroups)
+			}
+			if tc.LegacyWriteAllCustomerGroup != "" {
+				v.Set("service.writeAllCustomerGroup", tc.LegacyWriteAllCustomerGroup)
+			}
+			if tc.LegacyWriteAllGiantswarmGroup != "" {
+				v.Set("service.writeAllGiantswarmGroup", tc.LegacyWriteAllGiantswarmGroup)
+			}
+
+			config := Config{
+				Flag:   flag.New(),
+				Logger: logger,
+				Viper:  v,
+			}
+
+			_, err = New(config)
+
+			if tc.ExpectedError != nil && err == nil {
+				t.Fatalf("Failed to receive the expected error: %s", tc.ExpectedError)
+			}
+			if tc.ExpectedError != err && microerror.Cause(err) != tc.ExpectedError {
+				t.Fatalf("Received unexpected error: %s", err)
+			}
+		})
+	}
+}
+
+func mockKubernetesApiServer() *httptest.Server {
+	hf := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("{}"))
+	}
+	return httptest.NewServer(http.HandlerFunc(hf))
+}


### PR DESCRIPTION
## Checklist

Added support for creating roles for multiple admin roles defined in the config map.

The config map supports new properties in the `service` section to define multiple entries for each known admin group type:

```yaml
service:

  # ...

  accessGroups:
    writeAllCustomerGroups:
    - name: customer:giantswarm:Employees1
    - name: customer:giantswarm:Employees2
    writeAllGiantswarmGroups:
    - name: giantswarm:giantswarm:giantswarm-admins1
    - name: giantswarm:giantswarm:giantswarm-admins2
```

The old way of defining admin groups is also supported and can be combined with the new one:
```yaml
service:

  # ...

  writeAllCustomerGroup: customer:giantswarm:Employees
  writeAllGiantswarmGroup: giantswarm:giantswarm:giantswarm-admins

```

The operator will create RoleBindings and ClusterRoleBindings for all admin groups specified in the config.


- [ ] Update changelog in CHANGELOG.md.
- [ ] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation [giantswarm.io/notes](https://github.com/giantswarm/k8smetadata/blob/dff3b2358977e13c90479c66e21c728a96ddfe6d/pkg/annotation/general.go#L12) to help explain their purpose and usage.
