### PR TITLE
Migrate to app-build-suite

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -1,0 +1,3 @@
+replace-chart-version-with-git: true
+replace-app-version-with-git: true
+destination: ./build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ workflows:
 
       - architect/push-to-app-catalog:
           name: push-rbac-operator-to-control-plane-app-catalog
+          executor: app-build-suite
           context: architect
           app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate build step to app-build-suite
+
 ## [0.31.0] - 2022-12-01
 
 - Allow an array of write-all-groups.

--- a/helm/rbac-operator/Chart.yaml
+++ b/helm/rbac-operator/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-appVersion: [[ .AppVersion ]]
+appVersion: ""
 description: rbac-operator manages authorization for OIDC enabled control-plane Kubernetes APIs.
 home: https://github.com/giantswarm/rbac-operator
 name: rbac-operator
-version: [[ .Version ]]
+version: ""
 annotations:
   application.giantswarm.io/team: rainbow
   config.giantswarm.io/version: 1.x.x

--- a/helm/rbac-operator/templates/_helpers.tpl
+++ b/helm/rbac-operator/templates/_helpers.tpl
@@ -19,10 +19,9 @@ Common labels
 {{- define "labels.common" -}}
 app: {{ include "name" . | quote }}
 {{ include "labels.selector" . }}
-app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
-app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
 {{- end -}}
 

--- a/helm/rbac-operator/templates/deployment.yaml
+++ b/helm/rbac-operator/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
         runAsGroup: {{ .Values.pod.group.id }}
       containers:
       - name: {{ include "name" . }}
+        securityContext:
+          readOnlyRootFilesystem: true
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         args:
         - daemon

--- a/helm/rbac-operator/templates/deployment.yaml
+++ b/helm/rbac-operator/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
       - name: {{ include "name" . }}
         securityContext:
           readOnlyRootFilesystem: true
-        image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Chart.AppVersion }}"
         args:
         - daemon
         - --config.dirs=/var/run/{{ include "name" . }}/configmap/

--- a/helm/rbac-operator/values.schema.json
+++ b/helm/rbac-operator/values.schema.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "image": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "oidc": {
+            "type": "object",
+            "properties": {
+                "customer": {
+                    "type": "object",
+                    "properties": {
+                        "write_all_group": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "giantswarm": {
+                    "type": "object",
+                    "properties": {
+                        "write_all_group": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "pod": {
+            "type": "object",
+            "properties": {
+                "group": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "user": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        },
+        "registry": {
+            "type": "object",
+            "properties": {
+                "domain": {
+                    "type": "string"
+                },
+                "pullSecret": {
+                    "type": "object",
+                    "properties": {
+                        "dockerConfigJSON": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/helm/rbac-operator/values.schema.json
+++ b/helm/rbac-operator/values.schema.json
@@ -18,6 +18,9 @@
                     "properties": {
                         "write_all_group": {
                             "type": "string"
+                        },
+                        "write_all_groups": {
+                            "type": "array"
                         }
                     }
                 },
@@ -26,6 +29,9 @@
                     "properties": {
                         "write_all_group": {
                             "type": "string"
+                        },
+                        "write_all_groups": {
+                            "type": "array"
                         }
                     }
                 }

--- a/helm/rbac-operator/values.yaml
+++ b/helm/rbac-operator/values.yaml
@@ -1,6 +1,5 @@
 image:
   name: "giantswarm/rbac-operator"
-  tag: "[[ .Version ]]"
 
 pod:
   user:
@@ -18,7 +17,3 @@ oidc:
     write_all_group: ""
   giantswarm:
     write_all_group: ""
-
-project:
-  branch: "[[ .Branch ]]"
-  commit: "[[ .SHA ]]"

--- a/helm/rbac-operator/values.yaml
+++ b/helm/rbac-operator/values.yaml
@@ -15,5 +15,7 @@ registry:
 oidc:
   customer:
     write_all_group: ""
+    write_all_groups: []
   giantswarm:
     write_all_group: ""
+    write_all_groups: []


### PR DESCRIPTION
This PR migrates rbac-operator to abs. This will make it easier to integrate chart tests and is therefore towards https://github.com/giantswarm/giantswarm/issues/20068

Architect replaced some template values in the `values.yaml`, which abs does not do anymore.
I think that these values were not used for anything. As a reviewer please confirm that.

## Checklist

- [x] Update changelog in CHANGELOG.md.

