### PR TITLE
Fixing pods/log

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -10,4 +10,4 @@ CVE-2022-42709 until=2022-12-30
 # github.com/urfave/negroni
 sonatype-2021-1485 until=2022-12-30
 sonatype-2022-5436 until=2022-12-30
-
+sonatype-2022-6522 until=2022-12-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix `pods/log` policy rule.
+
 ## [0.31.1] - 2022-12-12
 
 ### Changed

--- a/service/internal/bootstrap/resources.go
+++ b/service/internal/bootstrap/resources.go
@@ -100,17 +100,18 @@ func (b *Bootstrap) createReadAllClusterRole(ctx context.Context) error {
 				}
 				policyRules = append(policyRules, policyRule)
 			}
-			// ServerPreferredResources explicitely ignores any resource containing a '/'
-			// but we require this for enabling pods/logs for customer access to
-			// kubernetes pod logging. This is appended as a specific rule instead.
-			policyRule := rbacv1.PolicyRule{
-				APIGroups: []string{""},
-				Resources: []string{"pods/log"},
-				Verbs:     []string{"get", "list"},
-			}
-			policyRules = append(policyRules, policyRule)
 		}
 	}
+
+	// ServerPreferredResources explicitely ignores any resource containing a '/'
+	// but we require this for enabling pods/logs for customer access to
+	// kubernetes pod logging. This is appended as a specific rule instead.
+	policyRule := rbacv1.PolicyRule{
+		APIGroups: []string{""},
+		Resources: []string{"pods/log"},
+		Verbs:     []string{"get", "list"},
+	}
+	policyRules = append(policyRules, policyRule)
 
 	readOnlyClusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description

When adding `pods/log` rule inside the loop we add it multiple times, so for clarity I think it is better to just move it outside the loop.

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation [giantswarm.io/notes](https://github.com/giantswarm/k8smetadata/blob/dff3b2358977e13c90479c66e21c728a96ddfe6d/pkg/annotation/general.go#L12) to help explain their purpose and usage.
