### PR TITLE
Remove FluxCD resources from the read-all ClusterRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Remove shared app collection from circle CI
+- Exclude Flux resources from the `read-all` role.
 
 ## [0.33.1] - 2023-03-29
 
@@ -18,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added the use of the runtime/default seccomp profile.
-- Added reconciliation of static resources like e.g. ClusterRoles, ClusterRoleBindings, ServiceAccounts in the default namespace, etc.  
+- Added reconciliation of static resources like e.g. ClusterRoles, ClusterRoleBindings, ServiceAccounts in the default namespace, etc.
 
 ## [0.32.0] - 2023-01-17
 


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation [giantswarm.io/notes](https://github.com/giantswarm/k8smetadata/blob/dff3b2358977e13c90479c66e21c728a96ddfe6d/pkg/annotation/general.go#L12) to help explain their purpose and usage.
