### PR TITLE
Fix appending `pods/log` policy rule to `read-all` ClusterRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `read-all` clusterRole to append `pods/log` policy rule once 
+
 ## [0.33.2] - 2023-05-04
 
 ### Changed

--- a/service/controller/defaultnamespace/resource/clusterroles/create.go
+++ b/service/controller/defaultnamespace/resource/clusterroles/create.go
@@ -110,17 +110,18 @@ func (r *Resource) createReadAllClusterRole(ctx context.Context) error {
 				}
 				policyRules = append(policyRules, policyRule)
 			}
-			// ServerPreferredResources explicitely ignores any resource containing a '/'
-			// but we require this for enabling pods/logs for customer access to
-			// kubernetes pod logging. This is appended as a specific rule instead.
-			policyRule := rbacv1.PolicyRule{
-				APIGroups: []string{""},
-				Resources: []string{"pods/log"},
-				Verbs:     []string{"get", "list"},
-			}
-			policyRules = append(policyRules, policyRule)
 		}
 	}
+
+	// ServerPreferredResources explicitely ignores any resource containing a '/'
+	// but we require this for enabling pods/logs for customer access to
+	// kubernetes pod logging. This is appended as a specific rule instead.
+	policyRule := rbacv1.PolicyRule{
+		APIGroups: []string{""},
+		Resources: []string{"pods/log"},
+		Verbs:     []string{"get", "list"},
+	}
+	policyRules = append(policyRules, policyRule)
 
 	readOnlyClusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{

--- a/service/controller/defaultnamespace/resource/clusterroles/create_test.go
+++ b/service/controller/defaultnamespace/resource/clusterroles/create_test.go
@@ -58,7 +58,6 @@ func Test_ClusterRoleCreation(t *testing.T) {
 			},
 			ExpectedClusterRoles: newExpectedClusterRoles([]rbacv1.PolicyRule{
 				defaultnamespacetest.NewSingleResourceRule("release.giantswarm.io", "releases"),
-				defaultnamespacetest.NewSingleResourceRule("", "pods/log"),
 			}),
 		},
 	}
@@ -186,7 +185,9 @@ func Test_ClusterRoleLabeling(t *testing.T) {
 
 func newExpectedClusterRoles(readAllRules []rbacv1.PolicyRule) []*rbacv1.ClusterRole {
 	return []*rbacv1.ClusterRole{
-		defaultnamespacetest.NewClusterRole(pkgkey.DefaultReadAllPermissionsName, readAllRules),
+		defaultnamespacetest.NewClusterRole(pkgkey.DefaultReadAllPermissionsName, append(readAllRules, defaultnamespacetest.NewSingleResourceRule(
+			"", "pods/log",
+		))),
 		defaultnamespacetest.NewClusterRole(pkgkey.WriteOrganizationsPermissionsName, defaultnamespacetest.NewSingletonRules(
 			[]string{"security.giantswarm.io"},
 			[]string{"organizations"},


### PR DESCRIPTION
We add a rule for `pods/log` to the `read-all` ClusterRole policy rules, but it was being added multiple times. This PR moves it outside of the loop, and should solve the issue described in https://github.com/giantswarm/roadmap/issues/2364.

I've tested it on the Azure test installation, but would appreciate if someone with more rbac-operator/Go expertise could take a look

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation [giantswarm.io/notes](https://github.com/giantswarm/k8smetadata/blob/dff3b2358977e13c90479c66e21c728a96ddfe6d/pkg/annotation/general.go#L12) to help explain their purpose and usage.
