### PR TITLE
Fixed reconciliation of group subjects in org namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `read-all` clusterRole to append `pods/log` policy rule once 
+- Fixed `read-all` clusterRole to append `pods/log` policy rule once
+- Fixed reconciling subjects in existing organization namespace role bindings
 
 ## [0.33.2] - 2023-05-04
 

--- a/go.mod
+++ b/go.mod
@@ -112,4 +112,5 @@ replace (
 	github.com/nats-io/nats-server/v2 => github.com/nats-io/nats-server/v2 v2.9.11
 	github.com/valyala/fasthttp => github.com/valyala/fasthttp v1.44.0
 	golang.org/x/text => golang.org/x/text v0.6.0
+	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0
 )

--- a/go.mod
+++ b/go.mod
@@ -112,5 +112,4 @@ replace (
 	github.com/nats-io/nats-server/v2 => github.com/nats-io/nats-server/v2 v2.9.11
 	github.com/valyala/fasthttp => github.com/valyala/fasthttp v1.44.0
 	golang.org/x/text => golang.org/x/text v0.6.0
-	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0
 )

--- a/service/controller/clusternamespace/resource/clusternamespaceresources/create_test.go
+++ b/service/controller/clusternamespace/resource/clusternamespaceresources/create_test.go
@@ -3,9 +3,10 @@ package clusternamespaceresources
 import (
 	"context"
 	"fmt"
-	"github.com/giantswarm/rbac-operator/service/test"
 	"reflect"
 	"testing"
+
+	"github.com/giantswarm/rbac-operator/service/test"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclienttest"
 	"github.com/giantswarm/micrologger/microloggertest"

--- a/service/controller/clusternamespace/resource/clusternamespaceresources/create_test.go
+++ b/service/controller/clusternamespace/resource/clusternamespaceresources/create_test.go
@@ -3,6 +3,7 @@ package clusternamespaceresources
 import (
 	"context"
 	"fmt"
+	"github.com/giantswarm/rbac-operator/service/test"
 	"reflect"
 	"testing"
 
@@ -31,13 +32,13 @@ func Test_EnsureCreated(t *testing.T) {
 		{
 			name: "flawless",
 			namespaces: []*corev1.Namespace{
-				newOrgNamespace("acme"),
-				newClusterNamespace("abc0", "acme"),
-				newGenericNamespace("giantswarm"),
+				test.NewOrgNamespace("acme"),
+				test.NewClusterNamespace("abc0", "acme"),
+				test.NewGenericNamespace("giantswarm"),
 			},
-			organization: newOrganization("acme"),
+			organization: test.NewOrganization("acme"),
 			roleBindings: []*rbacv1.RoleBinding{
-				newRoleBinding(
+				test.NewRoleBinding(
 					"flux-crd-controller",
 					"org-acme",
 					map[string]string{
@@ -53,7 +54,7 @@ func Test_EnsureCreated(t *testing.T) {
 						{Kind: "ServiceAccount", Name: "source-controller", Namespace: "flux-system"},
 					},
 				),
-				newRoleBinding(
+				test.NewRoleBinding(
 					"flux-namespace-reconciler",
 					"org-acme",
 					map[string]string{
@@ -65,7 +66,7 @@ func Test_EnsureCreated(t *testing.T) {
 						{Kind: "ServiceAccount", Name: "kustomize-controller", Namespace: "flux-system"},
 					},
 				),
-				newRoleBinding(
+				test.NewRoleBinding(
 					"cluster-ns-organization-acme-write",
 					"org-acme",
 					map[string]string{
@@ -76,7 +77,7 @@ func Test_EnsureCreated(t *testing.T) {
 						{Kind: "Group", Name: "customer:acme:Employees"},
 					},
 				),
-				newRoleBinding(
+				test.NewRoleBinding(
 					"cluster-ns-organization-acme-read",
 					"org-acme",
 					map[string]string{
@@ -89,7 +90,7 @@ func Test_EnsureCreated(t *testing.T) {
 				),
 			},
 			expectedRoleBindings: []*rbacv1.RoleBinding{
-				newRoleBinding(
+				test.NewRoleBinding(
 					"flux-crd-controller",
 					"abc0",
 					map[string]string{
@@ -105,7 +106,7 @@ func Test_EnsureCreated(t *testing.T) {
 						{Kind: "ServiceAccount", Name: "source-controller", Namespace: "flux-system"},
 					},
 				),
-				newRoleBinding(
+				test.NewRoleBinding(
 					"flux-namespace-reconciler",
 					"abc0",
 					map[string]string{
@@ -117,7 +118,7 @@ func Test_EnsureCreated(t *testing.T) {
 						{Kind: "ServiceAccount", Name: "kustomize-controller", Namespace: "flux-system"},
 					},
 				),
-				newRoleBinding(
+				test.NewRoleBinding(
 					"write-in-cluster-ns",
 					"abc0",
 					map[string]string{
@@ -128,7 +129,7 @@ func Test_EnsureCreated(t *testing.T) {
 						{Kind: "Group", Name: "customer:acme:Employees"},
 					},
 				),
-				newRoleBinding(
+				test.NewRoleBinding(
 					"read-in-cluster-ns",
 					"abc0",
 					map[string]string{

--- a/service/controller/clusternamespace/resource/clusternamespaceresources/delete_test.go
+++ b/service/controller/clusternamespace/resource/clusternamespaceresources/delete_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/giantswarm/rbac-operator/service/test"
+
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclienttest"
 	"github.com/giantswarm/micrologger/microloggertest"
 	corev1 "k8s.io/api/core/v1"
@@ -25,10 +27,10 @@ func Test_EnsureDeleted(t *testing.T) {
 			name:             "flawless",
 			clusterNamespace: "abc0",
 			namespaces: []*corev1.Namespace{
-				newClusterNamespace("abc0", "acme"),
+				test.NewClusterNamespace("abc0", "acme"),
 			},
 			roleBindings: []*rbacv1.RoleBinding{
-				newRoleBinding(
+				test.NewRoleBinding(
 					"flux-crd-controller",
 					"abc0",
 					map[string]string{
@@ -44,7 +46,7 @@ func Test_EnsureDeleted(t *testing.T) {
 						{Kind: "ServiceAccount", Name: "source-controller", Namespace: "flux-system"},
 					},
 				),
-				newRoleBinding(
+				test.NewRoleBinding(
 					"flux-namespace-reconciler",
 					"abc0",
 					map[string]string{
@@ -56,7 +58,7 @@ func Test_EnsureDeleted(t *testing.T) {
 						{Kind: "ServiceAccount", Name: "kustomize-controller", Namespace: "flux-system"},
 					},
 				),
-				newRoleBinding(
+				test.NewRoleBinding(
 					"write-in-cluster-ns",
 					"abc0",
 					map[string]string{
@@ -67,7 +69,7 @@ func Test_EnsureDeleted(t *testing.T) {
 						{Kind: "Group", Name: "customer:acme:Employees"},
 					},
 				),
-				newRoleBinding(
+				test.NewRoleBinding(
 					"read-in-cluster-ns",
 					"abc0",
 					map[string]string{

--- a/service/controller/rbac/resource/namespaceauth/create.go
+++ b/service/controller/rbac/resource/namespaceauth/create.go
@@ -3,12 +3,13 @@ package namespaceauth
 import (
 	"context"
 	"fmt"
+	"reflect"
+
 	k8smetadata "github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/microerror"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
 
 	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 

--- a/service/controller/rbac/resource/namespaceauth/create.go
+++ b/service/controller/rbac/resource/namespaceauth/create.go
@@ -3,12 +3,12 @@ package namespaceauth
 import (
 	"context"
 	"fmt"
-
 	k8smetadata "github.com/giantswarm/k8smetadata/pkg/label"
 	"github.com/giantswarm/microerror"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
 
 	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
 
@@ -178,5 +178,9 @@ func needsUpdate(desiredRoleBinding, existingRoleBinding *rbacv1.RoleBinding) bo
 		return true
 	}
 
-	return desiredRoleBinding.Subjects[0].Name != existingRoleBinding.Subjects[0].Name || desiredRoleBinding.Subjects[0].Namespace != existingRoleBinding.Subjects[0].Namespace || desiredRoleBinding.RoleRef.Name != existingRoleBinding.RoleRef.Name
+	if !reflect.DeepEqual(existingRoleBinding.RoleRef, desiredRoleBinding.RoleRef) {
+		return true
+	}
+
+	return !reflect.DeepEqual(existingRoleBinding.Subjects, desiredRoleBinding.Subjects)
 }

--- a/service/controller/rbac/resource/namespaceauth/create_test.go
+++ b/service/controller/rbac/resource/namespaceauth/create_test.go
@@ -1,0 +1,223 @@
+package namespaceauth
+
+import (
+	"context"
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclienttest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	security "github.com/giantswarm/organization-operator/api/v1alpha1"
+	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
+	"github.com/giantswarm/rbac-operator/service/test"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
+	"reflect"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func Test_EnsureCreated(t *testing.T) {
+
+	testCases := []struct {
+		name                string
+		orgNamespace        *v1.Namespace
+		existingResources   []runtime.Object
+		customerAdminGroups []accessgroup.AccessGroup
+		expectedClusterRole *rbacv1.ClusterRole
+		expectedRoleBinding *rbacv1.RoleBinding
+	}{
+		{
+			name:         "case 0: Create a new role binding in case it does not exist",
+			orgNamespace: test.NewOrgNamespace("giantswarm"),
+			customerAdminGroups: []accessgroup.AccessGroup{
+				{Name: "customer:giantswarm:Employees"},
+			},
+			expectedRoleBinding: test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+				"kind": "ClusterRole",
+				"name": "cluster-admin",
+			}, []rbacv1.Subject{
+				{Kind: "Group", Name: "customer:giantswarm:Employees"},
+			}),
+		},
+		{
+			name:         "case 1: Replace subjects in an existing role binding",
+			orgNamespace: test.NewOrgNamespace("giantswarm"),
+			existingResources: []runtime.Object{
+				test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+					"kind": "ClusterRole",
+					"name": "cluster-admin",
+				}, []rbacv1.Subject{
+					{Kind: "Group", Name: "customer:acme:Employees"},
+				}),
+			},
+			customerAdminGroups: []accessgroup.AccessGroup{
+				{Name: "customer:giantswarm:Employees"},
+			},
+			expectedRoleBinding: test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+				"kind": "ClusterRole",
+				"name": "cluster-admin",
+			}, []rbacv1.Subject{
+				{Kind: "Group", Name: "customer:giantswarm:Employees"},
+			}),
+		},
+		{
+			name:         "case 2: Add subjects to an existing role binding",
+			orgNamespace: test.NewOrgNamespace("giantswarm"),
+			existingResources: []runtime.Object{
+				test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+					"kind": "ClusterRole",
+					"name": "cluster-admin",
+				}, []rbacv1.Subject{
+					{Kind: "Group", Name: "customer:acme:Employees"},
+				}),
+			},
+			customerAdminGroups: []accessgroup.AccessGroup{
+				{Name: "customer:acme:Employees"},
+				{Name: "customer:giantswarm:Employees"},
+			},
+			expectedRoleBinding: test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+				"kind": "ClusterRole",
+				"name": "cluster-admin",
+			}, []rbacv1.Subject{
+				{Kind: "Group", Name: "customer:acme:Employees"},
+				{Kind: "Group", Name: "customer:giantswarm:Employees"},
+			}),
+		},
+		{
+			name:         "case 3: Remove subjects from an existing role binding",
+			orgNamespace: test.NewOrgNamespace("giantswarm"),
+			existingResources: []runtime.Object{
+				test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+					"kind": "ClusterRole",
+					"name": "cluster-admin",
+				}, []rbacv1.Subject{
+					{Kind: "Group", Name: "customer:acme:Employees"},
+					{Kind: "Group", Name: "customer:giantswarm:Employees"},
+				}),
+			},
+			customerAdminGroups: []accessgroup.AccessGroup{
+				{Name: "customer:giantswarm:Employees"},
+			},
+			expectedRoleBinding: test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+				"kind": "ClusterRole",
+				"name": "cluster-admin",
+			}, []rbacv1.Subject{
+				{Kind: "Group", Name: "customer:giantswarm:Employees"},
+			}),
+		},
+		{
+			name:         "case 4: Do not overwrite the role binding in case there are no changes",
+			orgNamespace: test.NewOrgNamespace("giantswarm"),
+			existingResources: []runtime.Object{
+				test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+					"kind": "ClusterRole",
+					"name": "cluster-admin",
+				}, []rbacv1.Subject{
+					{Kind: "Group", Name: "customer:acme:Employees"},
+					{Kind: "Group", Name: "customer:giantswarm:Employees"},
+				}),
+			},
+			customerAdminGroups: []accessgroup.AccessGroup{
+				{Name: "customer:acme:Employees"},
+				{Name: "customer:giantswarm:Employees"},
+			},
+			expectedRoleBinding: test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+				"kind": "ClusterRole",
+				"name": "cluster-admin",
+			}, []rbacv1.Subject{
+				{Kind: "Group", Name: "customer:acme:Employees"},
+				{Kind: "Group", Name: "customer:giantswarm:Employees"},
+			}),
+		},
+		{
+			name:         "case 5: Create cluster role",
+			orgNamespace: test.NewOrgNamespace("giantswarm"),
+			expectedClusterRole: test.NewClusterRole(
+				"organization-giantswarm-read",
+				*test.NewPolicyRule([]string{"get"}, []string{"organizations"}, []string{"giantswarm"}, []string{"security.giantswarm.io"})),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			var runtimeObjects []runtime.Object
+			if tc.orgNamespace != nil {
+				runtimeObjects = append(runtimeObjects, tc.orgNamespace)
+			}
+			runtimeObjects = append(runtimeObjects, tc.existingResources...)
+
+			var k8sClientFake *k8sclienttest.Clients
+			{
+				schemeBuilder := runtime.SchemeBuilder{
+					security.AddToScheme,
+				}
+
+				err = schemeBuilder.AddToScheme(scheme.Scheme)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				k8sClientFake = k8sclienttest.NewClients(k8sclienttest.ClientsConfig{
+					CtrlClient: clientfake.NewClientBuilder().
+						WithScheme(scheme.Scheme).
+						Build(),
+					K8sClient: clientgofake.NewSimpleClientset(runtimeObjects...),
+				})
+			}
+
+			namespaceAuth, err := New(Config{
+				K8sClient:              k8sClientFake,
+				Logger:                 microloggertest.New(),
+				WriteAllCustomerGroups: tc.customerAdminGroups,
+			})
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = namespaceAuth.EnsureCreated(context.TODO(), tc.orgNamespace)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.expectedClusterRole != nil {
+				checkClusterRole(t, k8sClientFake, tc.expectedClusterRole)
+			}
+
+			if tc.expectedRoleBinding != nil {
+				checkRoleBinding(t, k8sClientFake, tc.expectedRoleBinding)
+			}
+		})
+	}
+}
+
+func checkClusterRole(t *testing.T, k8sClient k8sclient.Interface, expectedClusterRole *rbacv1.ClusterRole) {
+	clusterRole, err := k8sClient.K8sClient().RbacV1().ClusterRoles().Get(context.TODO(), expectedClusterRole.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(expectedClusterRole.Rules, clusterRole.Rules) {
+		t.Fatalf("unexpected Rules - expected %s, received %s\n", expectedClusterRole.Rules, clusterRole.Rules)
+	}
+}
+
+func checkRoleBinding(t *testing.T, k8sClient k8sclient.Interface, expectedRoleBinding *rbacv1.RoleBinding) {
+	roleBinding, err := k8sClient.K8sClient().RbacV1().RoleBindings(expectedRoleBinding.Namespace).Get(context.TODO(), expectedRoleBinding.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(expectedRoleBinding.RoleRef, roleBinding.RoleRef) {
+		t.Fatalf("unexpected RoleRef - expected %s, received %s\n", expectedRoleBinding.RoleRef, roleBinding.RoleRef)
+	}
+
+	if !reflect.DeepEqual(expectedRoleBinding.Subjects, roleBinding.Subjects) {
+		t.Fatalf("unexpected Subjects - expected %s, received %s\n", expectedRoleBinding.Subjects, roleBinding.Subjects)
+	}
+}

--- a/service/controller/rbac/resource/namespaceauth/create_test.go
+++ b/service/controller/rbac/resource/namespaceauth/create_test.go
@@ -2,20 +2,22 @@ package namespaceauth
 
 import (
 	"context"
+	"reflect"
+	"testing"
+
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclienttest"
 	"github.com/giantswarm/micrologger/microloggertest"
 	security "github.com/giantswarm/organization-operator/api/v1alpha1"
-	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
-	"github.com/giantswarm/rbac-operator/service/test"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgofake "k8s.io/client-go/kubernetes/fake"
-	"reflect"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
+
+	"github.com/giantswarm/rbac-operator/service/internal/accessgroup"
+	"github.com/giantswarm/rbac-operator/service/test"
 
 	"k8s.io/client-go/kubernetes/scheme"
 )

--- a/service/test/common.go
+++ b/service/test/common.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"fmt"
+
 	k8smetadata "github.com/giantswarm/k8smetadata/pkg/label"
 	security "github.com/giantswarm/organization-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"

--- a/service/test/common.go
+++ b/service/test/common.go
@@ -1,8 +1,7 @@
-package clusternamespaceresources
+package test
 
 import (
 	"fmt"
-
 	k8smetadata "github.com/giantswarm/k8smetadata/pkg/label"
 	security "github.com/giantswarm/organization-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -10,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func newClusterNamespace(name, organization string) *corev1.Namespace {
+func NewClusterNamespace(name, organization string) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -22,7 +21,7 @@ func newClusterNamespace(name, organization string) *corev1.Namespace {
 	}
 }
 
-func newGenericNamespace(name string) *corev1.Namespace {
+func NewGenericNamespace(name string) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -30,7 +29,7 @@ func newGenericNamespace(name string) *corev1.Namespace {
 	}
 }
 
-func newOrganization(name string) *security.Organization {
+func NewOrganization(name string) *security.Organization {
 	return &security.Organization{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -41,19 +40,19 @@ func newOrganization(name string) *security.Organization {
 	}
 }
 
-func newOrgNamespace(name string) *corev1.Namespace {
+func NewOrgNamespace(orgName string) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				k8smetadata.ManagedBy:    "organization-operator",
-				k8smetadata.Organization: name,
+				k8smetadata.Organization: orgName,
 			},
-			Name: fmt.Sprintf("org-%s", name),
+			Name: fmt.Sprintf("org-%s", orgName),
 		},
 	}
 }
 
-func newRoleBinding(name, namespace string, roleRef map[string]string, subjects []rbacv1.Subject) *rbacv1.RoleBinding {
+func NewRoleBinding(name, namespace string, roleRef map[string]string, subjects []rbacv1.Subject) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "RoleBinding",
@@ -72,5 +71,28 @@ func newRoleBinding(name, namespace string, roleRef map[string]string, subjects 
 			Kind:     roleRef["kind"],
 			Name:     roleRef["name"],
 		},
+	}
+}
+
+func NewClusterRole(name string, rules ...rbacv1.PolicyRule) *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRole",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{},
+			Name:   name,
+		},
+		Rules: rules,
+	}
+}
+
+func NewPolicyRule(verbs, resources, resourceNames, apiGroups []string) *rbacv1.PolicyRule {
+	return &rbacv1.PolicyRule{
+		Verbs:         verbs,
+		Resources:     resources,
+		ResourceNames: resourceNames,
+		APIGroups:     apiGroups,
 	}
 }


### PR DESCRIPTION
In case a new customer admin group is added to the operator, it is not added to the `write-all-customer-group`  role bindings in organization namespaces. 

This PR fixes it and ensures that customer groups in organization namespace role bindings are updated correctly..

More details: https://github.com/giantswarm/roadmap/issues/2418

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation [giantswarm.io/notes](https://github.com/giantswarm/k8smetadata/blob/dff3b2358977e13c90479c66e21c728a96ddfe6d/pkg/annotation/general.go#L12) to help explain their purpose and usage.
