### PR TITLE
Update gin dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update dependency `gin` to `v1.9.0`
+
 ### Fixed
 
 - Fixed `read-all` clusterRole to append `pods/log` policy rule once 

--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 replace (
 	github.com/coreos/etcd => go.etcd.io/etcd/v3 v3.5.6
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.3
-	github.com/gin-gonic/gin v1.4.0 => github.com/gin-gonic/gin v1.7.7
+	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0
 	github.com/hashicorp/consul/api => github.com/hashicorp/consul/api v1.20.0
 	github.com/hashicorp/consul/sdk => github.com/hashicorp/consul/sdk v0.13.0
 	github.com/kataras/iris/v12 => github.com/kataras/iris/v12 v12.2.0


### PR DESCRIPTION
I tried to make a release but the build is failing in CI due to security vulnerabilities with `gin`. This updates it to the recommended version.

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation [giantswarm.io/notes](https://github.com/giantswarm/k8smetadata/blob/dff3b2358977e13c90479c66e21c728a96ddfe6d/pkg/annotation/general.go#L12) to help explain their purpose and usage.
