### PR TITLE
Update deployment to be PSS compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add chart tests for specific controllers.
+- Update deployment to be PSS compliant.
 
 ## [0.34.1] - 2023-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add chart tests for specific controllers.
+
 ## [0.34.0] - 2023-06-15
 
 ### Removed

--- a/helm/rbac-operator/templates/deployment.yaml
+++ b/helm/rbac-operator/templates/deployment.yaml
@@ -46,6 +46,11 @@ spec:
       - name: {{ include "name" . }}
         securityContext:
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
           {{- with .Values.securityContext }}
             {{- . | toYaml | nindent 10 }}
           {{- end }}


### PR DESCRIPTION
This PR updates the deployment to be PSS compliant.
Towards https://github.com/giantswarm/giantswarm/issues/27338

Fixed policy violations:
```
policy disallow-capabilities-strict -> resource default/Deployment/release-name failed: 
1. autogen-require-drop-all: validation failure: Containers must drop `ALL` capabilities. 

policy disallow-privilege-escalation -> resource default/Deployment/release-name failed: 
1. autogen-privilege-escalation: validation error: Privilege escalation is disallowed. The fields spec.containers[*].securityContext.allowPrivilegeEscalation, spec.initContainers[*].securityContext.allowPrivilegeEscalation, and spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation must be set to `false`. rule autogen-privilege-escalation failed at path /spec/template/spec/containers/0/securityContext/allowPrivilegeEscalation/ 

policy require-run-as-nonroot -> resource default/Deployment/release-name failed: 
1. autogen-run-as-non-root: validation error: Running as root is not allowed. Either the field spec.securityContext.runAsNonRoot must be set to `true`, or the fields spec.containers[*].securityContext.runAsNonRoot, spec.initContainers[*].securityContext.runAsNonRoot, and spec.ephemeralContainers[*].securityContext.runAsNonRoot must be set to `true`. rule autogen-run-as-non-root[0] failed at path /spec/template/spec/securityContext/runAsNonRoot/ rule autogen-run-as-non-root[1] failed at path /spec/template/spec/containers/0/securityContext/runAsNonRoot/ 
```
## Checklist

- [x] Update changelog in CHANGELOG.md.

