### PR TITLE
add check to fluxauth deletion to wait 15 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add check to fluxauth resource to only delete resources after 15 minutes to give flux enough time for cleanup.
+
 ## [0.34.3] - 2023-07-04
 
 ### Added

--- a/service/controller/rbac/resource/fluxauth/delete_test.go
+++ b/service/controller/rbac/resource/fluxauth/delete_test.go
@@ -1,0 +1,33 @@
+package fluxauth
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func Test_deletionTimeNotPassed(t *testing.T) {
+	tests := []struct {
+		name   string
+		time   time.Time
+		result bool
+	}{
+		{
+			name: "time passed",
+			time: time.Now().Add(-20 * time.Minute),
+		},
+		{
+			name:   "time not passed",
+			time:   time.Now().Add(-5 * time.Minute),
+			result: true,
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(fmt.Sprintf("case %d: %s", i, tc.name), func(t *testing.T) {
+			if tc.result != deletionTimeNotPassed(tc.time) {
+				t.Fatalf("Expected deletionTimeNotPassed to be %v for %v", tc.result, tc.time.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27486
Flux still needs permissions in the org namespace to clean up. Deleting the rbac resources will prevent this, resulting in leftovers and block org deletion.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation [giantswarm.io/notes](https://github.com/giantswarm/k8smetadata/blob/dff3b2358977e13c90479c66e21c728a96ddfe6d/pkg/annotation/general.go#L12) to help explain their purpose and usage.
