### PR TITLE
remove rolebindingtemplate.spec.template.spec

### DIFF
--- a/api/v1alpha1/rolebindingtemplate_types.go
+++ b/api/v1alpha1/rolebindingtemplate_types.go
@@ -60,9 +60,17 @@ type RoleBindingTemplateList struct {
 
 // RoleBindingTemplateResource describes the data needed to create a rolebinding from a template.
 type RoleBindingTemplateResource struct {
+	// Standard object's metadata.
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Spec is the specification of the desired rolebinding
-	Spec rbacv1.RoleBinding `json:"spec"`
+	// Subjects holds references to the objects the role applies to.
+	// +optional
+	Subjects []rbacv1.Subject `json:"subjects,omitempty"`
+
+	// RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace.
+	// If the RoleRef cannot be resolved, the Authorizer must return an error.
+	RoleRef rbacv1.RoleRef `json:"roleRef"`
 }
 
 // RoleBindingTemplateScopes describes the scopes the RoleBindingTemplate should be applied to

--- a/config/crd/auth.giantswarm.io_rolebindingtemplates.yaml
+++ b/config/crd/auth.giantswarm.io_rolebindingtemplates.yaml
@@ -55,86 +55,67 @@ spec:
                 description: RoleBindingTemplateResource describes the data needed
                   to create a rolebinding from a template.
                 properties:
-                  spec:
-                    description: Spec is the specification of the desired rolebinding
+                  metadata:
+                    description: Standard object's metadata.
+                    type: object
+                  roleRef:
+                    description: RoleRef can reference a Role in the current namespace
+                      or a ClusterRole in the global namespace. If the RoleRef cannot
+                      be resolved, the Authorizer must return an error.
                     properties:
-                      apiVersion:
-                        description: 'APIVersion defines the versioned schema of this
-                          representation of an object. Servers should convert recognized
-                          schemas to the latest internal value, and may reject unrecognized
-                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                      apiGroup:
+                        description: APIGroup is the group for the resource being
+                          referenced
                         type: string
                       kind:
-                        description: 'Kind is a string value representing the REST
-                          resource this object represents. Servers may infer this
-                          from the endpoint the client submits requests to. Cannot
-                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        description: Kind is the type of resource being referenced
                         type: string
-                      metadata:
-                        description: Standard object's metadata.
-                        type: object
-                      roleRef:
-                        description: RoleRef can reference a Role in the current namespace
-                          or a ClusterRole in the global namespace. If the RoleRef
-                          cannot be resolved, the Authorizer must return an error.
-                        properties:
-                          apiGroup:
-                            description: APIGroup is the group for the resource being
-                              referenced
-                            type: string
-                          kind:
-                            description: Kind is the type of resource being referenced
-                            type: string
-                          name:
-                            description: Name is the name of resource being referenced
-                            type: string
-                        required:
-                        - apiGroup
-                        - kind
-                        - name
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      subjects:
-                        description: Subjects holds references to the objects the
-                          role applies to.
-                        items:
-                          description: Subject contains a reference to the object
-                            or user identities a role binding applies to.  This can
-                            either hold a direct API object reference, or a value
-                            for non-objects such as user and group names.
-                          properties:
-                            apiGroup:
-                              description: APIGroup holds the API group of the referenced
-                                subject. Defaults to "" for ServiceAccount subjects.
-                                Defaults to "rbac.authorization.k8s.io" for User and
-                                Group subjects.
-                              type: string
-                            kind:
-                              description: Kind of object being referenced. Values
-                                defined by this API group are "User", "Group", and
-                                "ServiceAccount". If the Authorizer does not recognized
-                                the kind value, the Authorizer should report an error.
-                              type: string
-                            name:
-                              description: Name of the object being referenced.
-                              type: string
-                            namespace:
-                              description: Namespace of the referenced object.  If
-                                the object kind is non-namespace, such as "User" or
-                                "Group", and this value is not empty the Authorizer
-                                should report an error.
-                              type: string
-                          required:
-                          - kind
-                          - name
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        type: array
+                      name:
+                        description: Name is the name of resource being referenced
+                        type: string
                     required:
-                    - roleRef
+                    - apiGroup
+                    - kind
+                    - name
                     type: object
+                    x-kubernetes-map-type: atomic
+                  subjects:
+                    description: Subjects holds references to the objects the role
+                      applies to.
+                    items:
+                      description: Subject contains a reference to the object or user
+                        identities a role binding applies to.  This can either hold
+                        a direct API object reference, or a value for non-objects
+                        such as user and group names.
+                      properties:
+                        apiGroup:
+                          description: APIGroup holds the API group of the referenced
+                            subject. Defaults to "" for ServiceAccount subjects. Defaults
+                            to "rbac.authorization.k8s.io" for User and Group subjects.
+                          type: string
+                        kind:
+                          description: Kind of object being referenced. Values defined
+                            by this API group are "User", "Group", and "ServiceAccount".
+                            If the Authorizer does not recognized the kind value,
+                            the Authorizer should report an error.
+                          type: string
+                        name:
+                          description: Name of the object being referenced.
+                          type: string
+                        namespace:
+                          description: Namespace of the referenced object.  If the
+                            object kind is non-namespace, such as "User" or "Group",
+                            and this value is not empty the Authorizer should report
+                            an error.
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
                 required:
-                - spec
+                - roleRef
                 type: object
             required:
             - scopes

--- a/service/controller/rolebindingtemplate/resource/rolebinding/create_test.go
+++ b/service/controller/rolebindingtemplate/resource/rolebinding/create_test.go
@@ -149,7 +149,9 @@ func TestGetRoleBindingFromTemplate(t *testing.T) {
 				},
 				Spec: v1alpha1.RoleBindingTemplateSpec{
 					Template: v1alpha1.RoleBindingTemplateResource{
-						Spec: *tc.Template,
+						ObjectMeta: tc.Template.ObjectMeta,
+						RoleRef:    tc.Template.RoleRef,
+						Subjects:   tc.Template.Subjects,
 					},
 				},
 			}

--- a/service/controller/rolebindingtemplate/resource/rolebinding/resource.go
+++ b/service/controller/rolebindingtemplate/resource/rolebinding/resource.go
@@ -104,7 +104,7 @@ func (r *Resource) getNamespacesFromScope(ctx context.Context, scopes v1alpha1.R
 }
 
 func getRoleBindingNameFromTemplate(template v1alpha1.RoleBindingTemplate) string {
-	roleBindingName := template.Spec.Template.Spec.Name
+	roleBindingName := template.Spec.Template.ObjectMeta.Name
 	if roleBindingName == "" {
 		roleBindingName = template.Name
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2709

`spec` is not an attribute of roleBindings, so instead of `spec` we reference `roleRef` and `subjects` directly within the template resource.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation [giantswarm.io/notes](https://github.com/giantswarm/k8smetadata/blob/dff3b2358977e13c90479c66e21c728a96ddfe6d/pkg/annotation/general.go#L12) to help explain their purpose and usage.
