### PR TITLE
Fixed applying RoleBindingTemplate to multiple namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix applying RoleBindingTemplate to multiple namespaces
+
 ## [0.37.1] - 2023-08-30
 
 ### Added

--- a/service/controller/rolebindingtemplate/resource/rolebinding/create.go
+++ b/service/controller/rolebindingtemplate/resource/rolebinding/create.go
@@ -93,12 +93,13 @@ func getRoleBindingFromTemplate(template v1alpha1.RoleBindingTemplate, namespace
 	}
 
 	// ensure subjects
-	subjects := template.Spec.Template.Subjects
+	var subjects []rbacv1.Subject
 	{
-		for i, s := range subjects {
-			if s.Kind == rbacv1.ServiceAccountKind && s.Namespace == "" {
-				subjects[i].Namespace = namespace
+		for _, subject := range template.Spec.Template.Subjects {
+			if subject.Kind == rbacv1.ServiceAccountKind && subject.Namespace == "" {
+				subject.Namespace = namespace
 			}
+			subjects = append(subjects, subject)
 		}
 	}
 


### PR DESCRIPTION
When a single RoleBindingTemplate needs to be applied to multiple namespaces, subjects of role bindings created from the template may have subjects with incorrect namespaces.

This PR fixes that.

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation [giantswarm.io/notes](https://github.com/giantswarm/k8smetadata/blob/dff3b2358977e13c90479c66e21c728a96ddfe6d/pkg/annotation/general.go#L12) to help explain their purpose and usage.
