### PR TITLE
Fix flaky tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Try to fix flaky tests by increasing retries.
+
 ## [0.37.2] - 2023-09-01
 
 ### Fixed

--- a/tests/ats/test_rbac_controller_externalresources.py
+++ b/tests/ats/test_rbac_controller_externalresources.py
@@ -67,7 +67,7 @@ class TestRBACControllerExternalResources:
 
         return org_namespace, cluster_namespace
 
-    @retry()
+    @retry(max_retries=10)
     def check_created(self):
         LOGGER.info("Checking for expected cluster role bindings and roles")
         # raises if not found
@@ -89,7 +89,7 @@ class TestRBACControllerExternalResources:
         cluster_namespace.delete()
         LOGGER.info("Deleted org and cluster namespaces")
 
-    @retry()
+    @retry(max_retries=10)
     def check_deleted(self):
         try:
             for expected_cluster_role_name in EXPECTED_CLUSTER_ROLE_BINDING_NAMES:


### PR DESCRIPTION
On the previous PR by renovate bot the following test failed: `TestRBACControllerExternalResources::test_rbac_controller_external_resources`
I tried it out a couple of times locally and it seems that the test is flaky. 
This PR increases the maximum number of retries from 5 to 10.
 

## Checklist

- [x] Update changelog in CHANGELOG.md.