### PR TITLE
restrict access to org-giantswarm namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Restrict access to `org-giantswarm` namespace
+
 ## [0.39.0] - 2023-10-26
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,6 @@ replace (
 	github.com/kataras/iris/v12 => github.com/kataras/iris/v12 v12.2.7
 	github.com/labstack/echo/v4 => github.com/labstack/echo/v4 v4.11.2
 	github.com/microcosm-cc/bluemonday => github.com/microcosm-cc/bluemonday v1.0.26
-	github.com/nats-io/nats-server/v2 => github.com/nats-io/nats-server/v2 v2.10.4
 	github.com/valyala/fasthttp => github.com/valyala/fasthttp v1.50.0
 	golang.org/x/text => golang.org/x/text v0.13.0
 )

--- a/go.mod
+++ b/go.mod
@@ -113,6 +113,8 @@ replace (
 	github.com/kataras/iris/v12 => github.com/kataras/iris/v12 v12.2.7
 	github.com/labstack/echo/v4 => github.com/labstack/echo/v4 v4.11.2
 	github.com/microcosm-cc/bluemonday => github.com/microcosm-cc/bluemonday v1.0.26
+	github.com/nats-io/nats-server/v2 => github.com/nats-io/nats-server/v2 v2.10.4
+	github.com/nats-io/nkeys => github.com/nats-io/nkeys v0.4.6
 	github.com/valyala/fasthttp => github.com/valyala/fasthttp v1.50.0
 	golang.org/x/text => golang.org/x/text v0.13.0
 )

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -62,6 +62,10 @@ func IsOrgNamespace(ns string) bool {
 	return strings.HasPrefix(ns, "org-")
 }
 
+func IsProtectedNamespace(ns string) bool {
+	return ns == "org-giantswarm"
+}
+
 func Organization(getter rbacLabel.LabelsGetter) string {
 	return getter.GetLabels()[label.Organization]
 }

--- a/pkg/rbac/role_binding.go
+++ b/pkg/rbac/role_binding.go
@@ -31,7 +31,7 @@ func RoleBindingNeedsUpdate(desiredRoleBinding, existingRoleBinding *rbacv1.Role
 func CreateOrUpdateRoleBinding(c base.K8sClientWithLogging, ctx context.Context, namespace string, roleBinding *rbacv1.RoleBinding) error {
 	existingRoleBinding, err := c.K8sClient().RbacV1().RoleBindings(namespace).Get(ctx, roleBinding.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		c.Logger().LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Creating RoleBinding %#q in namespce %s.", roleBinding.Name, namespace))
+		c.Logger().LogCtx(ctx, "level", "info", "message", fmt.Sprintf("Creating RoleBinding %#q in namespace %s.", roleBinding.Name, namespace))
 
 		_, err := c.K8sClient().RbacV1().RoleBindings(namespace).Create(ctx, roleBinding, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {

--- a/service/controller/defaultnamespace/defaultnamespacetest/test_methods.go
+++ b/service/controller/defaultnamespace/defaultnamespacetest/test_methods.go
@@ -75,7 +75,7 @@ func RoleBindingsShouldEqual(t *testing.T, expected []*rbacv1.RoleBinding, actua
 	for _, expectedItem := range expected {
 		hasItem := false
 		for _, actualItem := range actual {
-			if expectedItem.ObjectMeta.Name == actualItem.ObjectMeta.Name {
+			if expectedItem.ObjectMeta.Name == actualItem.ObjectMeta.Name && expectedItem.ObjectMeta.Namespace == actualItem.ObjectMeta.Namespace {
 				hasItem = true
 				SubjectsShouldEqual(t, actualItem.Kind, actualItem.Name, expectedItem.Subjects, actualItem.Subjects)
 				break

--- a/service/controller/rbac/resource/namespaceauth/create.go
+++ b/service/controller/rbac/resource/namespaceauth/create.go
@@ -131,63 +131,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 	}
 
-	// Bind ClusterRole 'cluster-admin' to the 'automation' SA in the 'default' namespace.
-	{
-		roleBindingToAutomationSAName := pkgkey.WriteAllAutomationSARoleBindingName()
-
-		writeAllRoleBindingToAutomationSA := &rbacv1.RoleBinding{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "RoleBinding",
-				APIVersion: "rbac.authorization.k8s.io/v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: roleBindingToAutomationSAName,
-				Labels: map[string]string{
-					k8smetadata.ManagedBy: project.Name(),
-				},
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      pkgkey.AutomationServiceAccountName,
-					Namespace: pkgkey.DefaultNamespaceName,
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "ClusterRole",
-				Name:     pkgkey.ClusterAdminClusterRoleName,
-			},
-		}
-
-		roleBinding := writeAllRoleBindingToAutomationSA
-		_, err = r.k8sClient.RbacV1().RoleBindings(ns.Name).Get(ctx, roleBinding.Name, metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			if !pkgkey.IsProtectedNamespace(ns.Name) {
-				r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("creating rolebinding %#q in namespace %s", roleBinding.Name, ns.Name))
-
-				_, err := r.k8sClient.RbacV1().RoleBindings(ns.Name).Create(ctx, roleBinding, metav1.CreateOptions{})
-				if apierrors.IsAlreadyExists(err) {
-					// do nothing
-				} else if err != nil {
-					return microerror.Mask(err)
-				}
-
-				r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("rolebinding %#q in namespace %s has been created", roleBinding.Name, ns.Name))
-			}
-		} else if err != nil {
-			return microerror.Mask(err)
-		} else if pkgkey.IsProtectedNamespace(ns.Name) {
-			// delete the rolebinding
-			r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("deleting rolebinding %#q in namespace %s", roleBinding.Name, ns.Name))
-			err := r.k8sClient.RbacV1().RoleBindings(ns.Name).Delete(ctx, roleBinding.Name, metav1.DeleteOptions{})
-			if err != nil {
-				return microerror.Mask(err)
-			}
-			r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("rolebinding %#q in namespace %s has been deleted", roleBinding.Name, ns.Name))
-		}
-	}
-
 	return nil
 }
 

--- a/service/controller/rbac/resource/namespaceauth/create_test.go
+++ b/service/controller/rbac/resource/namespaceauth/create_test.go
@@ -34,11 +34,11 @@ func Test_EnsureCreated(t *testing.T) {
 	}{
 		{
 			name:         "case 0: Create a new role binding in case it does not exist",
-			orgNamespace: test.NewOrgNamespace("giantswarm"),
+			orgNamespace: test.NewOrgNamespace("customer"),
 			customerAdminGroups: []accessgroup.AccessGroup{
 				{Name: "customer:giantswarm:Employees"},
 			},
-			expectedRoleBinding: test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+			expectedRoleBinding: test.NewRoleBinding("write-all-customer-group", "org-customer", map[string]string{
 				"kind": "ClusterRole",
 				"name": "cluster-admin",
 			}, []rbacv1.Subject{
@@ -47,9 +47,9 @@ func Test_EnsureCreated(t *testing.T) {
 		},
 		{
 			name:         "case 1: Replace subjects in an existing role binding",
-			orgNamespace: test.NewOrgNamespace("giantswarm"),
+			orgNamespace: test.NewOrgNamespace("customer"),
 			existingResources: []runtime.Object{
-				test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+				test.NewRoleBinding("write-all-customer-group", "org-customer", map[string]string{
 					"kind": "ClusterRole",
 					"name": "cluster-admin",
 				}, []rbacv1.Subject{
@@ -59,7 +59,7 @@ func Test_EnsureCreated(t *testing.T) {
 			customerAdminGroups: []accessgroup.AccessGroup{
 				{Name: "customer:giantswarm:Employees"},
 			},
-			expectedRoleBinding: test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+			expectedRoleBinding: test.NewRoleBinding("write-all-customer-group", "org-customer", map[string]string{
 				"kind": "ClusterRole",
 				"name": "cluster-admin",
 			}, []rbacv1.Subject{
@@ -68,9 +68,9 @@ func Test_EnsureCreated(t *testing.T) {
 		},
 		{
 			name:         "case 2: Add subjects to an existing role binding",
-			orgNamespace: test.NewOrgNamespace("giantswarm"),
+			orgNamespace: test.NewOrgNamespace("customer"),
 			existingResources: []runtime.Object{
-				test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+				test.NewRoleBinding("write-all-customer-group", "org-customer", map[string]string{
 					"kind": "ClusterRole",
 					"name": "cluster-admin",
 				}, []rbacv1.Subject{
@@ -81,7 +81,7 @@ func Test_EnsureCreated(t *testing.T) {
 				{Name: "customer:acme:Employees"},
 				{Name: "customer:giantswarm:Employees"},
 			},
-			expectedRoleBinding: test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+			expectedRoleBinding: test.NewRoleBinding("write-all-customer-group", "org-customer", map[string]string{
 				"kind": "ClusterRole",
 				"name": "cluster-admin",
 			}, []rbacv1.Subject{
@@ -91,9 +91,9 @@ func Test_EnsureCreated(t *testing.T) {
 		},
 		{
 			name:         "case 3: Remove subjects from an existing role binding",
-			orgNamespace: test.NewOrgNamespace("giantswarm"),
+			orgNamespace: test.NewOrgNamespace("customer"),
 			existingResources: []runtime.Object{
-				test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+				test.NewRoleBinding("write-all-customer-group", "org-customer", map[string]string{
 					"kind": "ClusterRole",
 					"name": "cluster-admin",
 				}, []rbacv1.Subject{
@@ -104,7 +104,7 @@ func Test_EnsureCreated(t *testing.T) {
 			customerAdminGroups: []accessgroup.AccessGroup{
 				{Name: "customer:giantswarm:Employees"},
 			},
-			expectedRoleBinding: test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+			expectedRoleBinding: test.NewRoleBinding("write-all-customer-group", "org-customer", map[string]string{
 				"kind": "ClusterRole",
 				"name": "cluster-admin",
 			}, []rbacv1.Subject{
@@ -113,9 +113,9 @@ func Test_EnsureCreated(t *testing.T) {
 		},
 		{
 			name:         "case 4: Do not overwrite the role binding in case there are no changes",
-			orgNamespace: test.NewOrgNamespace("giantswarm"),
+			orgNamespace: test.NewOrgNamespace("customer"),
 			existingResources: []runtime.Object{
-				test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+				test.NewRoleBinding("write-all-customer-group", "org-customer", map[string]string{
 					"kind": "ClusterRole",
 					"name": "cluster-admin",
 				}, []rbacv1.Subject{
@@ -127,7 +127,7 @@ func Test_EnsureCreated(t *testing.T) {
 				{Name: "customer:acme:Employees"},
 				{Name: "customer:giantswarm:Employees"},
 			},
-			expectedRoleBinding: test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+			expectedRoleBinding: test.NewRoleBinding("write-all-customer-group", "org-customer", map[string]string{
 				"kind": "ClusterRole",
 				"name": "cluster-admin",
 			}, []rbacv1.Subject{
@@ -137,10 +137,32 @@ func Test_EnsureCreated(t *testing.T) {
 		},
 		{
 			name:         "case 5: Create cluster role",
-			orgNamespace: test.NewOrgNamespace("giantswarm"),
+			orgNamespace: test.NewOrgNamespace("customer"),
 			expectedClusterRole: test.NewClusterRole(
-				"organization-giantswarm-read",
-				*test.NewPolicyRule([]string{"get"}, []string{"organizations"}, []string{"giantswarm"}, []string{"security.giantswarm.io"})),
+				"organization-customer-read",
+				*test.NewPolicyRule([]string{"get"}, []string{"organizations"}, []string{"customer"}, []string{"security.giantswarm.io"})),
+		},
+		{
+			name:         "case 6: Do not create rolebinding in protected namespace",
+			orgNamespace: test.NewOrgNamespace("giantswarm"),
+			customerAdminGroups: []accessgroup.AccessGroup{
+				{Name: "customer:giantswarm:Employees"},
+			},
+		},
+		{
+			name:         "case 7: Delete rolebinding in protected namespace",
+			orgNamespace: test.NewOrgNamespace("giantswarm"),
+			existingResources: []runtime.Object{
+				test.NewRoleBinding("write-all-customer-group", "org-giantswarm", map[string]string{
+					"kind": "ClusterRole",
+					"name": "cluster-admin",
+				}, []rbacv1.Subject{
+					{Kind: "Group", Name: "customer:giantswarm:Employees"},
+				}),
+			},
+			customerAdminGroups: []accessgroup.AccessGroup{
+				{Name: "customer:giantswarm:Employees"},
+			},
 		},
 	}
 

--- a/service/controller/rolebindingtemplate/resource/rolebinding/create.go
+++ b/service/controller/rolebindingtemplate/resource/rolebinding/create.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/rbac-operator/api/v1alpha1"
+	pkgkey "github.com/giantswarm/rbac-operator/pkg/key"
 	"github.com/giantswarm/rbac-operator/pkg/project"
 	"github.com/giantswarm/rbac-operator/pkg/rbac"
 	"github.com/giantswarm/rbac-operator/service/controller/rolebindingtemplate/key"
@@ -34,11 +35,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		if err = rbac.CreateOrUpdateRoleBinding(r, ctx, ns, roleBinding); err != nil {
-			r.logger.Debugf(ctx, "Could not apply roleBinding %s to namespace %s due to error %v", roleBinding.Name, ns, err)
-			continue
+		if !isForbidden(roleBinding, ns) {
+			if err = rbac.CreateOrUpdateRoleBinding(r, ctx, ns, roleBinding); err != nil {
+				r.logger.Debugf(ctx, "Could not apply roleBinding %s to namespace %s due to error %v", roleBinding.Name, ns, err)
+				continue
+			}
+			status = append(status, ns)
 		}
-		status = append(status, ns)
 	}
 
 	// go through old list of namespaces and compare for scope changes
@@ -113,6 +116,22 @@ func getRoleBindingFromTemplate(template v1alpha1.RoleBindingTemplate, namespace
 		RoleRef:    roleRef,
 		Subjects:   subjects,
 	}, nil
+}
+
+func isForbidden(roleBinding *rbacv1.RoleBinding, namespace string) bool {
+	// the roleBinding is forbidden if its in a protected namespace and contains Subjects other than serviceAccounts in flux namespaces
+	if !pkgkey.IsProtectedNamespace(namespace) {
+		return false
+	}
+	for _, subject := range roleBinding.Subjects {
+		if subject.Kind != rbacv1.ServiceAccountKind {
+			return true
+		}
+		if subject.Namespace != pkgkey.FluxNamespaceName {
+			return true
+		}
+	}
+	return false
 }
 
 func incompleteRoleRef(roleRef rbacv1.RoleRef) bool {

--- a/service/controller/rolebindingtemplate/resource/rolebinding/create_test.go
+++ b/service/controller/rolebindingtemplate/resource/rolebinding/create_test.go
@@ -1,16 +1,27 @@
 package rolebinding
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclienttest"
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/k8smetadata/pkg/label"
+	"github.com/giantswarm/micrologger/microloggertest"
+	security "github.com/giantswarm/organization-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/giantswarm/rbac-operator/api/v1alpha1"
+	pkgkey "github.com/giantswarm/rbac-operator/pkg/key"
 	"github.com/giantswarm/rbac-operator/pkg/project"
+	"github.com/giantswarm/rbac-operator/service/controller/defaultnamespace/defaultnamespacetest"
 )
 
 func TestGetRoleBindingFromTemplate(t *testing.T) {
@@ -279,7 +290,304 @@ func TestGetRoleBindingFromTemplate(t *testing.T) {
 	}
 }
 
+func TestEnsureCreated(t *testing.T) {
+	testCases := []struct {
+		Name          string
+		Template      *v1alpha1.RoleBindingTemplate
+		Organizations []string
+
+		expectedRoleBindings []*rbacv1.RoleBinding
+		expectError          bool
+	}{
+		{
+			Name: "case1: create role binding in all orgs",
+			Template: &v1alpha1.RoleBindingTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "something",
+				},
+				Spec: v1alpha1.RoleBindingTemplateSpec{
+					Template: v1alpha1.RoleBindingTemplateResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "something",
+						},
+						RoleRef: rbacv1.RoleRef{
+							Name: "example",
+							Kind: "ClusterRole",
+						},
+						Subjects: []rbacv1.Subject{
+							{Kind: "Group", Name: "test-group"},
+							{Kind: "ServiceAccount", Name: "test-SA"},
+						},
+					},
+				},
+			},
+			Organizations:        []string{"example", "example-2"},
+			expectedRoleBindings: []*rbacv1.RoleBinding{getTestRoleBinding(), getTestRoleBindingInNS("org-example-2")},
+		},
+		{
+			Name: "case2: create role binding in one org",
+			Template: &v1alpha1.RoleBindingTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "something",
+				},
+				Spec: v1alpha1.RoleBindingTemplateSpec{
+					Template: v1alpha1.RoleBindingTemplateResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "something",
+						},
+						RoleRef: rbacv1.RoleRef{
+							Name: "example",
+							Kind: "ClusterRole",
+						},
+						Subjects: []rbacv1.Subject{
+							{Kind: "Group", Name: "test-group"},
+							{Kind: "ServiceAccount", Name: "test-SA"},
+						},
+					},
+					Scopes: v1alpha1.RoleBindingTemplateScopes{
+						OrganizationSelector: v1alpha1.ScopeSelector{
+							MatchLabels: map[string]string{"name": "example"},
+						},
+					},
+				},
+			},
+			Organizations:        []string{"example", "example-2"},
+			expectedRoleBindings: []*rbacv1.RoleBinding{getTestRoleBinding()},
+		},
+		{
+			Name: "case3: no matching orgs",
+			Template: &v1alpha1.RoleBindingTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "something",
+				},
+				Spec: v1alpha1.RoleBindingTemplateSpec{
+					Template: v1alpha1.RoleBindingTemplateResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "something",
+						},
+						RoleRef: rbacv1.RoleRef{
+							Name: "example",
+							Kind: "ClusterRole",
+						},
+						Subjects: []rbacv1.Subject{
+							{Kind: "Group", Name: "test-group"},
+							{Kind: "ServiceAccount", Name: "test-SA"},
+						},
+					},
+					Scopes: v1alpha1.RoleBindingTemplateScopes{
+						OrganizationSelector: v1alpha1.ScopeSelector{
+							MatchLabels: map[string]string{"name": "example-3"},
+						},
+					},
+				},
+			},
+			Organizations:        []string{"example", "example-2"},
+			expectedRoleBindings: []*rbacv1.RoleBinding{},
+		},
+		{
+			Name: "case4: do not create rolebinding in org-giantswarm namespace",
+			Template: &v1alpha1.RoleBindingTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "something",
+				},
+				Spec: v1alpha1.RoleBindingTemplateSpec{
+					Template: v1alpha1.RoleBindingTemplateResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "something",
+						},
+						RoleRef: rbacv1.RoleRef{
+							Name: "example",
+							Kind: "ClusterRole",
+						},
+						Subjects: []rbacv1.Subject{
+							{Kind: "Group", Name: "test-group"},
+							{Kind: "ServiceAccount", Name: "test-SA"},
+						},
+					},
+				},
+			},
+			Organizations:        []string{"example", "example-2", "giantswarm"},
+			expectedRoleBindings: []*rbacv1.RoleBinding{getTestRoleBinding(), getTestRoleBindingInNS("org-example-2")},
+		},
+		{
+			Name: "case5: create rolebinding in org-giantswarm namespace",
+			Template: &v1alpha1.RoleBindingTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "something",
+				},
+				Spec: v1alpha1.RoleBindingTemplateSpec{
+					Template: v1alpha1.RoleBindingTemplateResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "something",
+						},
+						RoleRef: rbacv1.RoleRef{
+							Name: "example",
+							Kind: "ClusterRole",
+						},
+						Subjects: []rbacv1.Subject{
+							{Kind: "ServiceAccount", Name: "test-SA", Namespace: pkgkey.FluxNamespaceName},
+						},
+					},
+				},
+			},
+			Organizations: []string{"example", "giantswarm"},
+			expectedRoleBindings: []*rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "something",
+						Namespace: "org-giantswarm",
+						Labels: map[string]string{
+							label.ManagedBy: project.Name(),
+						},
+						Annotations: map[string]string{
+							annotation.Notes: "Generated based on RoleBindingTemplate something",
+						},
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "RoleBinding",
+						APIVersion: "rbac.authorization.k8s.io/v1",
+					},
+					RoleRef: rbacv1.RoleRef{
+						Name:     "example",
+						Kind:     "ClusterRole",
+						APIGroup: "rbac.authorization.k8s.io",
+					},
+					Subjects: []rbacv1.Subject{
+						{Kind: "ServiceAccount", Name: "test-SA", Namespace: pkgkey.FluxNamespaceName},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "something",
+						Namespace: "org-example",
+						Labels: map[string]string{
+							label.ManagedBy: project.Name(),
+						},
+						Annotations: map[string]string{
+							annotation.Notes: "Generated based on RoleBindingTemplate something",
+						},
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "RoleBinding",
+						APIVersion: "rbac.authorization.k8s.io/v1",
+					},
+					RoleRef: rbacv1.RoleRef{
+						Name:     "example",
+						Kind:     "ClusterRole",
+						APIGroup: "rbac.authorization.k8s.io",
+					},
+					Subjects: []rbacv1.Subject{
+						{Kind: "ServiceAccount", Name: "test-SA", Namespace: pkgkey.FluxNamespaceName},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			objects := []runtime.Object{tc.Template}
+			namespaces := []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "example",
+					},
+				},
+			}
+			for _, org := range tc.Organizations {
+				objects = append(objects, getTestOrganization(org))
+				namespaces = append(namespaces, &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "org-" + org,
+					},
+				})
+			}
+			var k8sClientFake *k8sclienttest.Clients
+			{
+				schemeBuilder := runtime.SchemeBuilder{
+					security.AddToScheme,
+					v1alpha1.AddToScheme,
+				}
+				if err := schemeBuilder.AddToScheme(scheme.Scheme); err != nil {
+					t.Fatal(err)
+				}
+
+				k8sClientFake = k8sclienttest.NewClients(k8sclienttest.ClientsConfig{
+					CtrlClient: clientfake.NewClientBuilder().
+						WithScheme(scheme.Scheme).
+						WithRuntimeObjects(objects...).
+						Build(),
+					K8sClient: clientgofake.NewSimpleClientset(namespaces...),
+				})
+			}
+
+			r, err := New(Config{
+				K8sClient: k8sClientFake,
+				Logger:    microloggertest.New(),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx := context.Background()
+			err = r.EnsureCreated(ctx, tc.Template)
+			if !tc.expectError && err != nil {
+				t.Fatalf("Expected success, got error %v", err)
+			}
+			if tc.expectError && err == nil {
+				t.Fatalf("Expected error, got success")
+			}
+			roleBindingList, err := k8sClientFake.K8sClient().RbacV1().RoleBindings("").List(ctx, metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("failed to get role bindings: %s", err)
+			}
+			defaultnamespacetest.RoleBindingsShouldEqual(t, tc.expectedRoleBindings, roleBindingList.Items)
+		})
+	}
+}
+
+func getTestOrganization(name string) *security.Organization {
+	return &security.Organization{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"name": name,
+			},
+		},
+		Status: security.OrganizationStatus{
+			Namespace: "org-" + name,
+		},
+	}
+}
+
 func getTestRoleBinding() *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "something",
+			Namespace: "org-example",
+			Labels: map[string]string{
+				label.ManagedBy: project.Name(),
+			},
+			Annotations: map[string]string{
+				annotation.Notes: "Generated based on RoleBindingTemplate something",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name:     "example",
+			Kind:     "ClusterRole",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+		Subjects: []rbacv1.Subject{
+			{Kind: "Group", Name: "test-group"},
+			{Kind: "ServiceAccount", Name: "test-SA", Namespace: "org-example"},
+		},
+	}
+}
+
+func getTestRoleBindingInNS(namespace string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "something",

--- a/service/controller/rolebindingtemplate/resource/rolebinding/create_test.go
+++ b/service/controller/rolebindingtemplate/resource/rolebinding/create_test.go
@@ -401,13 +401,37 @@ func TestEnsureCreated(t *testing.T) {
 						},
 						Subjects: []rbacv1.Subject{
 							{Kind: "Group", Name: "test-group"},
-							{Kind: "ServiceAccount", Name: "test-SA"},
 						},
 					},
 				},
 			},
-			Organizations:        []string{"example", "example-2", "giantswarm"},
-			expectedRoleBindings: []*rbacv1.RoleBinding{getTestRoleBinding(), getTestRoleBindingInNS("org-example-2")},
+			Organizations: []string{"example", "giantswarm"},
+			expectedRoleBindings: []*rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "something",
+						Namespace: "org-example",
+						Labels: map[string]string{
+							label.ManagedBy: project.Name(),
+						},
+						Annotations: map[string]string{
+							annotation.Notes: "Generated based on RoleBindingTemplate something",
+						},
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "RoleBinding",
+						APIVersion: "rbac.authorization.k8s.io/v1",
+					},
+					RoleRef: rbacv1.RoleRef{
+						Name:     "example",
+						Kind:     "ClusterRole",
+						APIGroup: "rbac.authorization.k8s.io",
+					},
+					Subjects: []rbacv1.Subject{
+						{Kind: "Group", Name: "test-group"},
+					},
+				},
+			},
 		},
 		{
 			Name: "case5: create rolebinding in org-giantswarm namespace",
@@ -478,6 +502,89 @@ func TestEnsureCreated(t *testing.T) {
 					},
 					Subjects: []rbacv1.Subject{
 						{Kind: "ServiceAccount", Name: "test-SA", Namespace: pkgkey.FluxNamespaceName},
+					},
+				},
+			},
+		},
+		{
+			Name: "case6: create rolebinding in org-giantswarm namespace and remove invalid subjects",
+			Template: &v1alpha1.RoleBindingTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "something",
+				},
+				Spec: v1alpha1.RoleBindingTemplateSpec{
+					Template: v1alpha1.RoleBindingTemplateResource{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "something",
+						},
+						RoleRef: rbacv1.RoleRef{
+							Name: "example",
+							Kind: "ClusterRole",
+						},
+						Subjects: []rbacv1.Subject{
+							{Kind: "ServiceAccount", Name: "test-SA-1", Namespace: pkgkey.FluxNamespaceName},
+							{Kind: "ServiceAccount", Name: "test-SA-2", Namespace: "org-example"},
+							{Kind: "ServiceAccount", Name: "test-SA-3", Namespace: "org-giantswarm"},
+							{Kind: "ServiceAccount", Name: "test-SA-4"},
+							{Kind: "Group", Name: "test-group"},
+						},
+					},
+				},
+			},
+			Organizations: []string{"example", "giantswarm"},
+			expectedRoleBindings: []*rbacv1.RoleBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "something",
+						Namespace: "org-example",
+						Labels: map[string]string{
+							label.ManagedBy: project.Name(),
+						},
+						Annotations: map[string]string{
+							annotation.Notes: "Generated based on RoleBindingTemplate something",
+						},
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "RoleBinding",
+						APIVersion: "rbac.authorization.k8s.io/v1",
+					},
+					RoleRef: rbacv1.RoleRef{
+						Name:     "example",
+						Kind:     "ClusterRole",
+						APIGroup: "rbac.authorization.k8s.io",
+					},
+					Subjects: []rbacv1.Subject{
+						{Kind: "ServiceAccount", Name: "test-SA-1", Namespace: pkgkey.FluxNamespaceName},
+						{Kind: "ServiceAccount", Name: "test-SA-2", Namespace: "org-example"},
+						{Kind: "ServiceAccount", Name: "test-SA-3", Namespace: "org-giantswarm"},
+						{Kind: "ServiceAccount", Name: "test-SA-4", Namespace: "org-example"},
+						{Kind: "Group", Name: "test-group"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "something",
+						Namespace: "org-giantswarm",
+						Labels: map[string]string{
+							label.ManagedBy: project.Name(),
+						},
+						Annotations: map[string]string{
+							annotation.Notes: "Generated based on RoleBindingTemplate something",
+						},
+					},
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "RoleBinding",
+						APIVersion: "rbac.authorization.k8s.io/v1",
+					},
+					RoleRef: rbacv1.RoleRef{
+						Name:     "example",
+						Kind:     "ClusterRole",
+						APIGroup: "rbac.authorization.k8s.io",
+					},
+					Subjects: []rbacv1.Subject{
+						{Kind: "ServiceAccount", Name: "test-SA-1", Namespace: pkgkey.FluxNamespaceName},
+						{Kind: "ServiceAccount", Name: "test-SA-3", Namespace: "org-giantswarm"},
+						{Kind: "ServiceAccount", Name: "test-SA-4", Namespace: "org-giantswarm"},
 					},
 				},
 			},


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26439

## Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation [giantswarm.io/notes](https://github.com/giantswarm/k8smetadata/blob/dff3b2358977e13c90479c66e21c728a96ddfe6d/pkg/annotation/general.go#L12) to help explain their purpose and usage.
