### PR TITLE
Fix missing cluster-wide write permissions for customer admin groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix missing cluster-wide write permissions for customer admin groups by adding the missing `write-all-customer-group` ClusterRoleBinding.
+
 ## [0.42.2] - 2025-09-17
 
 ### Added

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -120,6 +120,10 @@ func WriteAllCustomerGroupRoleBindingName() string {
 	return fmt.Sprintf("%s-customer-group", DefaultWriteAllPermissionsName)
 }
 
+func WriteAllCustomerGroupClusterRoleBindingName() string {
+	return fmt.Sprintf("%s-customer-group", DefaultWriteAllPermissionsName)
+}
+
 func WriteAllAutomationSARoleBindingName() string {
 	return fmt.Sprintf("%s-customer-sa", DefaultWriteAllPermissionsName)
 }

--- a/service/controller/defaultnamespace/defaultnamespace_test.go
+++ b/service/controller/defaultnamespace/defaultnamespace_test.go
@@ -34,7 +34,7 @@ func Test_DefaultNamespaceController(t *testing.T) {
 			CustomerAdminGroups:          []accessgroup.AccessGroup{{Name: "customer"}},
 			GSAdminGroup:                 []accessgroup.AccessGroup{{Name: "giantswarm"}},
 			ExpectedClusterRoles:         9,
-			ExpectedClusterRoleBindings:  7,
+			ExpectedClusterRoleBindings:  8,
 			ExpectedRoles:                1,
 			ExpectedRoleBindings:         2,
 			ExpectedRoleBindingTemplates: 3,

--- a/service/controller/defaultnamespace/resource/usergroups/create_test.go
+++ b/service/controller/defaultnamespace/resource/usergroups/create_test.go
@@ -52,6 +52,10 @@ func Test_UserGroups(t *testing.T) {
 					defaultnamespacetest.NewGroupSubjects("customers1", "customers2"),
 				),
 				defaultnamespacetest.NewClusterRoleBinding(
+					pkgkey.WriteAllCustomerGroupClusterRoleBindingName(),
+					defaultnamespacetest.NewGroupSubjects("customers1", "customers2"),
+				),
+				defaultnamespacetest.NewClusterRoleBinding(
 					pkgkey.WriteAllGSGroupClusterRoleBindingName(),
 					defaultnamespacetest.NewGroupSubjects("giantswarm1", "giantswarm2"),
 				),
@@ -94,6 +98,10 @@ func Test_UserGroups(t *testing.T) {
 				),
 				defaultnamespacetest.NewClusterRoleBinding(
 					pkgkey.ReadAllCustomerGroupClusterRoleBindingName(),
+					defaultnamespacetest.NewGroupSubjects("customers1", "customers2"),
+				),
+				defaultnamespacetest.NewClusterRoleBinding(
+					pkgkey.WriteAllCustomerGroupClusterRoleBindingName(),
 					defaultnamespacetest.NewGroupSubjects("customers1", "customers2"),
 				),
 				defaultnamespacetest.NewClusterRoleBinding(


### PR DESCRIPTION
Fix missing cluster-wide write permissions for customer admin groups by adding the missing `write-all-customer-group` ClusterRoleBinding.

## Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] If the change introduces new roles, please consider adding user-friendly descriptions to the roles with the annotation [giantswarm.io/notes](https://github.com/giantswarm/k8smetadata/blob/dff3b2358977e13c90479c66e21c728a96ddfe6d/pkg/annotation/general.go#L12) to help explain their purpose and usage.
