### PR TITLE
feat: Add kamaji-datastore-manager permissions for automation SAs in org namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Create a per-organization ClusterRoleBinding granting the org's `automation` ServiceAccount the `kamaji-datastore-manager` ClusterRole, so cluster apps using Kamaji can manage their `kamaji.clastix.io/datastores` CR. The referenced ClusterRole is provisioned by the global Kamaji app.
+
 ## [0.44.0] - 2026-03-25
 
 ### Added

--- a/helm/rbac-operator/templates/_helpers.tpl
+++ b/helm/rbac-operator/templates/_helpers.tpl
@@ -20,7 +20,7 @@ Common labels
 app: {{ include "name" . | quote }}
 {{ include "labels.selector" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | trunc 63 | trimSuffix "-" | quote }}
 application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
 {{- end -}}

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -33,6 +33,7 @@ const (
 	WriteSilencesPermissionsName               = "write-silences"
 	WriteAWSClusterRoleIdentityPermissionsName = "write-aws-cluster-role-identity"
 	WritePolicyExceptionsPermissionsName       = "write-policy-exceptions"
+	KamajiDatastoreManagerPermissionsName      = "kamaji-datastore-manager"
 	CrossplaneEditRoleBindingName              = "crossplane-edit-automation"
 )
 
@@ -156,6 +157,10 @@ func WriteSilencesAutomationSARoleBindingName() string {
 
 func WriteSilencesAutomationSAinNSRoleBindingName(namespace string) string {
 	return fmt.Sprintf("%s-customer-sa-ns-%s", WriteSilencesPermissionsName, namespace)
+}
+
+func KamajiDatastoreManagerAutomationSAinNSRoleBindingName(namespace string) string {
+	return fmt.Sprintf("%s-customer-sa-ns-%s", KamajiDatastoreManagerPermissionsName, namespace)
 }
 
 func WriteAWSClusterRoleIdentityAutomationSARoleBindingName() string {

--- a/service/controller/rbac/resource/automation/create.go
+++ b/service/controller/rbac/resource/automation/create.go
@@ -63,7 +63,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 	}
 
-	// create a RoleBinding granting :
+	// create a ClusterRoleBinding granting :
 	// - write-silences access for "automation" ServiceAccount *in this org namespace*
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -84,6 +84,32 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	if err := r.createOrUpdateClusterRoleBinding(ctx, ns, clusterRoleBinding); err != nil {
+		return microerror.Mask(err)
+	}
+
+	// create a ClusterRoleBinding granting :
+	// - kamaji datastore management for "automation" ServiceAccount *in this org namespace*
+	// The referenced ClusterRole is provisioned by the global Kamaji app; the binding is
+	// inert on clusters where that role doesn't exist.
+	kamajiDatastoreBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pkgkey.KamajiDatastoreManagerAutomationSAinNSRoleBindingName(ns.Name),
+			Labels: map[string]string{
+				label.ManagedBy: project.Name(),
+			},
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      pkgkey.AutomationServiceAccountName,
+			Namespace: ns.Name}},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     pkgkey.KamajiDatastoreManagerPermissionsName,
+		},
+	}
+
+	if err := r.createOrUpdateClusterRoleBinding(ctx, ns, kamajiDatastoreBinding); err != nil {
 		return microerror.Mask(err)
 	}
 	return nil

--- a/service/controller/rbac/resource/automation/delete.go
+++ b/service/controller/rbac/resource/automation/delete.go
@@ -28,6 +28,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 
 	clusterRoleBindings := []string{
 		pkgkey.WriteSilencesAutomationSAinNSRoleBindingName(ns.Name),
+		pkgkey.KamajiDatastoreManagerAutomationSAinNSRoleBindingName(ns.Name),
 	}
 
 	for _, clusterRoleBinding := range clusterRoleBindings {


### PR DESCRIPTION
## Summary

- Extends the `automation` resource handler to also create a per-org `ClusterRoleBinding` binding `<org-ns>/automation` to the `kamaji-datastore-manager` `ClusterRole`.
- Mirrors the existing `write-silences-customer-sa-ns-<ns>` binding in shape and lifecycle: created on org-namespace reconcile, deleted in `EnsureDeleted`.

## Why

The cluster chart's Kamaji integration creates a Flux `HelmRelease` (`kamaji-etcd`) that runs as the org's `automation` ServiceAccount and provisions a cluster-scoped `kamaji.clastix.io/Datastore` CR. Previously the cluster chart attempted to bootstrap that RBAC itself, but installs of the cluster chart in non-whitelisted org namespaces go through chart-operator's "public" client (impersonating `default/automation`), which lacks `clusterroles.create` — so the install fails before any of the chart's content takes effect.

Owning the RBAC bootstrap here, alongside the SA itself, removes that ordering/permission problem. The `ClusterRole` `kamaji-datastore-manager` is provisioned by the global Kamaji app, not this repo; the binding is inert on clusters where that role doesn't exist.

## Notes

- The naming convention follows the existing `write-silences` pattern (`kamaji-datastore-manager-customer-sa-ns-<ns>`).
- The binding is created for **every** `org-*` namespace, including those that never run Kamaji clusters. The grant is effectively dormant when no `Datastore` CR/CRD exists.
- Cleanup is handled by extending the existing `clusterRoleBindings` list in `EnsureDeleted`.

## Test plan

- [ ] CI green (go build, go vet, existing tests)
- [ ] After release, verify a new binding `kamaji-datastore-manager-customer-sa-ns-<org>` appears in each `org-*` namespace's reconcile output
- [ ] Verify `kubectl auth can-i create datastores.kamaji.clastix.io --as=system:serviceaccount:org-xav:automation` returns `yes` (requires the `kamaji-datastore-manager` ClusterRole to exist)
- [ ] Verify deletion of an `org-*` namespace removes the matching binding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cluster PR: https://github.com/giantswarm/cluster/pull/887
Kamaji-app PR: https://github.com/giantswarm/kamaji-app/pull/37